### PR TITLE
fix: update links in home page sections

### DIFF
--- a/packages/docs/src/components/pages/home/Intro-section.astro
+++ b/packages/docs/src/components/pages/home/Intro-section.astro
@@ -14,8 +14,8 @@
       React, Svelte, and more. Experience simplicity and power in one package
     </p>
     <div class="mt-[52px] flex gap-4 md:mt-10 md:gap-4">
-      <a href="/docs" class="button border-2 border-white"> Read the Docs </a>
-      <a href="/tutorial" class="button bg-[#3992FF]"> Try tutorial </a>
+      <a href="/docs/introduction" class="button border-2 border-white"> Read the Docs </a>
+      <a href="/tutorial/introduction" class="button bg-[#3992FF]"> Try tutorial </a>
     </div>
   </div>
   <div

--- a/packages/docs/src/components/pages/home/last-section.astro
+++ b/packages/docs/src/components/pages/home/last-section.astro
@@ -15,7 +15,7 @@
       >, but your design was too good to resist! 😅)
     </p>
     <a
-      href="/docs"
+      href="docs/introduction"
       class="button rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-600"
     >
       Go Flitter around!


### PR DESCRIPTION
I've noticed that some buttons on the Flitter official documentation show a redirect screen when clicked.
I determined that the issue was caused by not specifying the correct path, so I rerouted it.

### [Read the Docs]
https://github.com/user-attachments/assets/354bad18-2124-4644-bb64-441070ee6482

### [Try tutorial]
https://github.com/user-attachments/assets/bdc22826-ee95-4107-856c-16e1072d3588

### [Go Flitter Around!]
https://github.com/user-attachments/assets/f5239192-be25-47f8-9d5b-9de63d44f18d