### PR TITLE
feat: support z-index on canvas rendering

### DIFF
--- a/packages/flitter/package.json
+++ b/packages/flitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meursyphus/flitter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Flitter: A high-performance JavaScript rendering engine and framework inspired by Flutter. Features declarative programming, SVG and Canvas support, and optimized for complex data visualizations, interactive charts, and graphic editors in web applications.",
   "keywords": [
     "rendering-engine",

--- a/packages/flitter/src/component/base/BaseClipPath.ts
+++ b/packages/flitter/src/component/base/BaseClipPath.ts
@@ -134,25 +134,14 @@ class ClipPathCanvasPainter extends CanvasPainter {
     );
   }
 
-  override get hasCanvasState(): boolean {
-    return true;
-  }
-
-  override applyCanvasState(
-    ctx: CanvasRenderingContext2D,
-    offset: Offset,
-  ): void {
-    ctx.translate(offset.x, offset.y);
-    ctx.clip(this.clipper.toCanvasPath());
-    ctx.translate(-offset.x, -offset.y);
-  }
-
   protected override performPaint(
     context: CanvasPaintingContext,
     offset: Offset,
   ): void {
     context.canvas.save();
-    this.applyCanvasState(context.canvas, offset);
+    context.canvas.translate(offset.x, offset.y);
+    context.canvas.clip(this.clipper.toCanvasPath());
+    context.canvas.translate(-offset.x, -offset.y);
     this.defaultPaint(context, offset);
     context.canvas.restore();
   }

--- a/packages/flitter/src/component/base/BaseClipPath.ts
+++ b/packages/flitter/src/component/base/BaseClipPath.ts
@@ -133,14 +133,26 @@ class ClipPathCanvasPainter extends CanvasPainter {
       this.renderObject.size,
     );
   }
+
+  override get hasCanvasState(): boolean {
+    return true;
+  }
+
+  override applyCanvasState(
+    ctx: CanvasRenderingContext2D,
+    offset: Offset,
+  ): void {
+    ctx.translate(offset.x, offset.y);
+    ctx.clip(this.clipper.toCanvasPath());
+    ctx.translate(-offset.x, -offset.y);
+  }
+
   protected override performPaint(
     context: CanvasPaintingContext,
     offset: Offset,
   ): void {
     context.canvas.save();
-    context.canvas.translate(offset.x, offset.y);
-    context.canvas.clip(this.clipper.toCanvasPath());
-    context.canvas.translate(-offset.x, -offset.y);
+    this.applyCanvasState(context.canvas, offset);
     this.defaultPaint(context, offset);
     context.canvas.restore();
   }

--- a/packages/flitter/src/component/base/BaseOpacity.ts
+++ b/packages/flitter/src/component/base/BaseOpacity.ts
@@ -80,6 +80,17 @@ class CanvasPainterOpacity extends CanvasPainter {
     return (this.renderObject as RenderOpacity).opacityProp;
   }
 
+  override get hasCanvasState(): boolean {
+    return true;
+  }
+
+  override applyCanvasState(
+    ctx: CanvasRenderingContext2D,
+    _offset: Offset,
+  ): void {
+    ctx.globalAlpha *= this.opacity;
+  }
+
   override performPaint(context: CanvasPaintingContext, offset: Offset) {
     const oldAlpha = context.canvas.globalAlpha;
     context.canvas.globalAlpha = oldAlpha * this.opacity;

--- a/packages/flitter/src/component/base/BaseOpacity.ts
+++ b/packages/flitter/src/component/base/BaseOpacity.ts
@@ -80,22 +80,11 @@ class CanvasPainterOpacity extends CanvasPainter {
     return (this.renderObject as RenderOpacity).opacityProp;
   }
 
-  override get hasCanvasState(): boolean {
-    return true;
-  }
-
-  override applyCanvasState(
-    ctx: CanvasRenderingContext2D,
-    _offset: Offset,
-  ): void {
-    ctx.globalAlpha *= this.opacity;
-  }
-
   override performPaint(context: CanvasPaintingContext, offset: Offset) {
-    const oldAlpha = context.canvas.globalAlpha;
-    context.canvas.globalAlpha = oldAlpha * this.opacity;
+    context.canvas.save();
+    context.canvas.globalAlpha *= this.opacity;
     this.defaultPaint(context, offset);
-    context.canvas.globalAlpha = oldAlpha;
+    context.canvas.restore();
   }
 }
 

--- a/packages/flitter/src/component/base/BaseTransform.ts
+++ b/packages/flitter/src/component/base/BaseTransform.ts
@@ -253,7 +253,14 @@ class TransformCanvasPainter extends CanvasPainter {
     return (this.renderObject as RenderTransform)._effectiveTransform;
   }
 
-  protected performPaint(context: CanvasPaintingContext, offset: Offset): void {
+  override get hasCanvasState(): boolean {
+    return true;
+  }
+
+  override applyCanvasState(
+    ctx: CanvasRenderingContext2D,
+    offset: Offset,
+  ): void {
     const arr = this.effectiveTransform._m4storage;
     const a = arr[0],
       b = arr[1],
@@ -261,11 +268,14 @@ class TransformCanvasPainter extends CanvasPainter {
       d = arr[5],
       e = arr[12],
       f = arr[13];
+    ctx.translate(offset.x, offset.y);
+    ctx.transform(a, b, c, d, e, f);
+    ctx.translate(-offset.x, -offset.y);
+  }
 
+  protected performPaint(context: CanvasPaintingContext, offset: Offset): void {
     context.canvas.save();
-    context.canvas.translate(offset.x, offset.y);
-    context.canvas.transform(a, b, c, d, e, f);
-    context.canvas.translate(-offset.x, -offset.y);
+    this.applyCanvasState(context.canvas, offset);
     this.defaultPaint(context, offset);
     context.canvas.restore();
   }

--- a/packages/flitter/src/component/base/BaseTransform.ts
+++ b/packages/flitter/src/component/base/BaseTransform.ts
@@ -253,29 +253,12 @@ class TransformCanvasPainter extends CanvasPainter {
     return (this.renderObject as RenderTransform)._effectiveTransform;
   }
 
-  override get hasCanvasState(): boolean {
-    return true;
-  }
-
-  override applyCanvasState(
-    ctx: CanvasRenderingContext2D,
-    offset: Offset,
-  ): void {
-    const arr = this.effectiveTransform._m4storage;
-    const a = arr[0],
-      b = arr[1],
-      c = arr[4],
-      d = arr[5],
-      e = arr[12],
-      f = arr[13];
-    ctx.translate(offset.x, offset.y);
-    ctx.transform(a, b, c, d, e, f);
-    ctx.translate(-offset.x, -offset.y);
-  }
-
   protected performPaint(context: CanvasPaintingContext, offset: Offset): void {
+    const arr = this.effectiveTransform._m4storage;
     context.canvas.save();
-    this.applyCanvasState(context.canvas, offset);
+    context.canvas.translate(offset.x, offset.y);
+    context.canvas.transform(arr[0], arr[1], arr[4], arr[5], arr[12], arr[13]);
+    context.canvas.translate(-offset.x, -offset.y);
     this.defaultPaint(context, offset);
     context.canvas.restore();
   }

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
@@ -29,26 +29,6 @@ export class CanvasPainter extends Painter {
     });
   }
 
-  /**
-   * Whether this painter modifies canvas state (transform, clip, opacity)
-   * that descendants need to inherit. Override in subclasses.
-   */
-  get hasCanvasState(): boolean {
-    return false;
-  }
-
-  /**
-   * Apply this painter's canvas state modifications without painting children.
-   * Called during z-ordered painting to replay ancestor state chain.
-   * Override in subclasses that modify canvas state.
-   */
-  applyCanvasState(
-    _ctx: CanvasRenderingContext2D,
-    _offset: Offset,
-  ): void {
-    // Base: no-op
-  }
-
   get paintBounds(): Rect {
     return Rect.fromLTWH({
       left: this.offset.x,

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
@@ -5,7 +5,6 @@ import type { CanvasRenderPipeline } from "./canvas-renderer";
 import type { CanvasPaintingContext } from "./canvas-painting-context";
 import { OffsetLayer, type ContainerLayer } from "./layer";
 import { assert } from "../../../utils";
-import type { RenderObject } from "../../../renderobject";
 
 export class CanvasPainter extends Painter {
   get renderOwner(): CanvasRenderPipeline {
@@ -25,14 +24,29 @@ export class CanvasPainter extends Painter {
   }
 
   protected defaultPaint(context: CanvasPaintingContext, offset: Offset) {
-    const children: RenderObject[] = [];
-    this.renderObject.visitChildren(child => children.push(child));
-    children.sort(
-      (a, b) => a.minDescendantZOrder - b.minDescendantZOrder,
-    );
-    for (const child of children) {
+    this.renderObject.visitChildren(child => {
       context.paintChild(child, offset.plus(child.offset));
-    }
+    });
+  }
+
+  /**
+   * Whether this painter modifies canvas state (transform, clip, opacity)
+   * that descendants need to inherit. Override in subclasses.
+   */
+  get hasCanvasState(): boolean {
+    return false;
+  }
+
+  /**
+   * Apply this painter's canvas state modifications without painting children.
+   * Called during z-ordered painting to replay ancestor state chain.
+   * Override in subclasses that modify canvas state.
+   */
+  applyCanvasState(
+    _ctx: CanvasRenderingContext2D,
+    _offset: Offset,
+  ): void {
+    // Base: no-op
   }
 
   get paintBounds(): Rect {

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
@@ -5,6 +5,7 @@ import type { CanvasRenderPipeline } from "./canvas-renderer";
 import type { CanvasPaintingContext } from "./canvas-painting-context";
 import { OffsetLayer, type ContainerLayer } from "./layer";
 import { assert } from "../../../utils";
+import type { RenderObject } from "../../../renderobject";
 
 export class CanvasPainter extends Painter {
   get renderOwner(): CanvasRenderPipeline {
@@ -24,9 +25,14 @@ export class CanvasPainter extends Painter {
   }
 
   protected defaultPaint(context: CanvasPaintingContext, offset: Offset) {
-    this.renderObject.visitChildren(child => {
+    const children: RenderObject[] = [];
+    this.renderObject.visitChildren(child => children.push(child));
+    children.sort(
+      (a, b) => a.minDescendantZOrder - b.minDescendantZOrder,
+    );
+    for (const child of children) {
       context.paintChild(child, offset.plus(child.offset));
-    });
+    }
   }
 
   get paintBounds(): Rect {

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painter.ts
@@ -14,6 +14,7 @@ export class CanvasPainter extends Painter {
     return false;
   }
 
+
   paint(context: CanvasPaintingContext, offset: Offset) {
     this.needsPaint = false;
     this.performPaint(context, offset);

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -8,15 +8,63 @@ import {
   type Layer,
 } from "./layer";
 import { NotImplementedError } from "../../../exception";
-import type { CanvasPainter } from "./canvas-painter";
 
-type AncestorState = { painter: CanvasPainter; offset: Offset };
+type AncestorNode = { node: RenderObject; offset: Offset };
 
 type CollectedPainter = {
   renderObject: RenderObject;
   offset: Offset;
-  ancestors: AncestorState[];
+  ancestors: AncestorNode[];
 };
+
+type CanvasProxy = CanvasRenderingContext2D & {
+  __enterSuppress: () => void;
+  __exitSuppress: () => void;
+  __raw: CanvasRenderingContext2D;
+};
+
+function createCanvasProxy(ctx: CanvasRenderingContext2D): CanvasProxy {
+  let suppressDepth = 0;
+  let suppressing = false;
+
+  const proxy = new Proxy(ctx, {
+    get(target, prop, receiver) {
+      if (prop === "__enterSuppress")
+        return () => {
+          suppressing = true;
+          suppressDepth = 0;
+        };
+      if (prop === "__exitSuppress")
+        return () => {
+          suppressing = false;
+        };
+      if (prop === "__raw") return target;
+
+      if (suppressing) {
+        if (prop === "save") {
+          return () => {
+            suppressDepth++;
+            if (suppressDepth > 1) target.save();
+          };
+        }
+        if (prop === "restore") {
+          return () => {
+            if (suppressDepth > 1) target.restore();
+            suppressDepth--;
+          };
+        }
+      }
+
+      const val = Reflect.get(target, prop, receiver);
+      return typeof val === "function" ? val.bind(target) : val;
+    },
+    set(target, prop, value) {
+      return Reflect.set(target, prop, value);
+    },
+  });
+
+  return proxy as CanvasProxy;
+}
 
 export class CanvasPaintingContext {
   #estimateBound: Rect;
@@ -59,7 +107,7 @@ export class CanvasPaintingContext {
       node.canvasPainter.paintBounds,
     );
 
-    // Phase 1: Collect all painter render objects with ancestor state chains
+    // Phase 1: Collect all painter render objects with ancestor node chains
     const painters: CollectedPainter[] = [];
     CanvasPaintingContext.#collectPainters(
       node,
@@ -72,15 +120,19 @@ export class CanvasPaintingContext {
     painters.sort((a, b) => a.renderObject.zOrder - b.renderObject.zOrder);
 
     // Phase 3: Paint each painter in z-order with ancestor ctx state replayed
+    const proxyCanvas = childContext.canvas as unknown as CanvasProxy;
     childContext.#skipChildPainting = true;
     for (const { renderObject, offset, ancestors } of painters) {
-      const ctx = childContext.canvas;
-      ctx.save();
-      for (const ancestor of ancestors) {
-        ancestor.painter.applyCanvasState(ctx, ancestor.offset);
+      proxyCanvas.__raw.save();
+      // Replay ancestors with suppressed save/restore
+      for (const { node: ancestorNode, offset: ancOffset } of ancestors) {
+        proxyCanvas.__enterSuppress();
+        ancestorNode.canvasPainter.paint(childContext, ancOffset);
+        proxyCanvas.__exitSuppress();
       }
+      // Paint the actual painter
       renderObject.canvasPainter.paint(childContext, offset);
-      ctx.restore();
+      proxyCanvas.__raw.restore();
     }
     childContext.#skipChildPainting = false;
 
@@ -89,12 +141,12 @@ export class CanvasPaintingContext {
 
   /**
    * Walk the render object tree and collect all painter render objects
-   * with their accumulated offsets and ancestor canvas state chains.
+   * with their accumulated offsets and ancestor node chains.
    */
   static #collectPainters(
     node: RenderObject,
     offset: Offset,
-    ancestorChain: AncestorState[],
+    ancestorChain: AncestorNode[],
     result: CollectedPainter[],
   ) {
     if (node.isPainter) {
@@ -105,13 +157,7 @@ export class CanvasPaintingContext {
       });
     }
 
-    // If this node's canvas painter modifies ctx state, add it to the
-    // ancestor chain so descendants will inherit the state.
-    let childAncestorChain = ancestorChain;
-    const painter = node.canvasPainter;
-    if (painter.hasCanvasState) {
-      childAncestorChain = [...ancestorChain, { painter, offset }];
-    }
+    const childAncestorChain = [...ancestorChain, { node, offset }];
 
     node.visitChildren(child => {
       CanvasPaintingContext.#collectPainters(
@@ -128,7 +174,7 @@ export class CanvasPaintingContext {
   }
 
   #recorder: PictureRecorder;
-  #ctx: CanvasRenderingContext2D | null;
+  #ctx: CanvasProxy | null;
   get canvas(): CanvasRenderingContext2D {
     if (this.#ctx == null) {
       this.#startRecording();
@@ -139,7 +185,7 @@ export class CanvasPaintingContext {
   #startRecording() {
     this.#currentLayer = new PictureLayer(this.#estimateBound);
     this.#recorder = new PictureRecorder(this.#estimateBound);
-    this.#ctx = this.#recorder.createCanvasContext();
+    this.#ctx = createCanvasProxy(this.#recorder.createCanvasContext());
     this.#containerLayer.append(this.#currentLayer!);
   }
 

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -23,6 +23,22 @@ type CanvasProxy = CanvasRenderingContext2D & {
   __raw: CanvasRenderingContext2D;
 };
 
+// Drawing operations that produce pixels — suppressed during ancestor replay
+// so that only canvas state changes (transforms, clips, opacity) persist.
+const DRAWING_OPS: ReadonlySet<string | symbol> = new Set([
+  "fillRect",
+  "strokeRect",
+  "clearRect",
+  "fill",
+  "stroke",
+  "fillText",
+  "strokeText",
+  "drawImage",
+  "putImageData",
+]);
+
+const NOOP = () => {};
+
 function createCanvasProxy(ctx: CanvasRenderingContext2D): CanvasProxy {
   let suppressDepth = 0;
   let suppressing = false;
@@ -53,9 +69,13 @@ function createCanvasProxy(ctx: CanvasRenderingContext2D): CanvasProxy {
             suppressDepth--;
           };
         }
+        // Suppress pixel-drawing operations during ancestor replay
+        if (DRAWING_OPS.has(prop)) {
+          return NOOP;
+        }
       }
 
-      const val = Reflect.get(target, prop, receiver);
+      const val = Reflect.get(target, prop, target);
       return typeof val === "function" ? val.bind(target) : val;
     },
     set(target, prop, value) {
@@ -157,13 +177,13 @@ export class CanvasPaintingContext {
       });
     }
 
-    // Only non-painter nodes go into the ancestor chain.
-    // Painter nodes (Container, DecoratedBox, etc.) would draw pixels
-    // during ancestor replay, which is undesirable. Non-painter nodes
-    // that modify ctx state (Transform, Opacity) are safely replayed.
-    const childAncestorChain = node.isPainter
-      ? ancestorChain
-      : [...ancestorChain, { node, offset }];
+    // All nodes go into the ancestor chain. During ancestor replay,
+    // the proxy suppresses pixel-drawing operations (fillRect, fill,
+    // stroke, etc.) so only canvas state changes (transforms, clips,
+    // opacity) persist. This means any node type — whether it draws
+    // pixels (Container) or only modifies state (Transform, ClipPath)
+    // — can safely be replayed as an ancestor.
+    const childAncestorChain = [...ancestorChain, { node, offset }];
 
     node.visitChildren(child => {
       CanvasPaintingContext.#collectPainters(

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -8,6 +8,15 @@ import {
   type Layer,
 } from "./layer";
 import { NotImplementedError } from "../../../exception";
+import type { CanvasPainter } from "./canvas-painter";
+
+type AncestorState = { painter: CanvasPainter; offset: Offset };
+
+type CollectedPainter = {
+  renderObject: RenderObject;
+  offset: Offset;
+  ancestors: AncestorState[];
+};
 
 export class CanvasPaintingContext {
   #estimateBound: Rect;
@@ -17,6 +26,14 @@ export class CanvasPaintingContext {
     this.#estimateBound = estimateBound;
   }
   #currentLayer: PictureLayer | null;
+
+  /**
+   * When true, paintChild becomes a no-op. Used during z-ordered
+   * painting so that each painter's performPaint only draws itself
+   * without recursing into children (children are painted separately
+   * in z-order).
+   */
+  #skipChildPainting = false;
 
   static repaintCompositedChild(node: RenderObject): void {
     assert(
@@ -42,12 +59,68 @@ export class CanvasPaintingContext {
       node.canvasPainter.paintBounds,
     );
 
-    // Paint via normal tree walk. Children are sorted by minDescendantZOrder
-    // in CanvasPainter.defaultPaint, so z-ordering is handled naturally
-    // while preserving ancestor canvas state (transforms, clips, opacity).
-    node.canvasPainter.paint(childContext, Offset.Constants.zero);
+    // Phase 1: Collect all painter render objects with ancestor state chains
+    const painters: CollectedPainter[] = [];
+    CanvasPaintingContext.#collectPainters(
+      node,
+      Offset.Constants.zero,
+      [],
+      painters,
+    );
+
+    // Phase 2: Sort by z-order (calculated by ZOrderCalculatorVisitor)
+    painters.sort((a, b) => a.renderObject.zOrder - b.renderObject.zOrder);
+
+    // Phase 3: Paint each painter in z-order with ancestor ctx state replayed
+    childContext.#skipChildPainting = true;
+    for (const { renderObject, offset, ancestors } of painters) {
+      const ctx = childContext.canvas;
+      ctx.save();
+      for (const ancestor of ancestors) {
+        ancestor.painter.applyCanvasState(ctx, ancestor.offset);
+      }
+      renderObject.canvasPainter.paint(childContext, offset);
+      ctx.restore();
+    }
+    childContext.#skipChildPainting = false;
 
     childContext.stopRecording();
+  }
+
+  /**
+   * Walk the render object tree and collect all painter render objects
+   * with their accumulated offsets and ancestor canvas state chains.
+   */
+  static #collectPainters(
+    node: RenderObject,
+    offset: Offset,
+    ancestorChain: AncestorState[],
+    result: CollectedPainter[],
+  ) {
+    if (node.isPainter) {
+      result.push({
+        renderObject: node,
+        offset,
+        ancestors: [...ancestorChain],
+      });
+    }
+
+    // If this node's canvas painter modifies ctx state, add it to the
+    // ancestor chain so descendants will inherit the state.
+    let childAncestorChain = ancestorChain;
+    const painter = node.canvasPainter;
+    if (painter.hasCanvasState) {
+      childAncestorChain = [...ancestorChain, { painter, offset }];
+    }
+
+    node.visitChildren(child => {
+      CanvasPaintingContext.#collectPainters(
+        child,
+        offset.plus(child.offset),
+        childAncestorChain,
+        result,
+      );
+    });
   }
 
   static updateLayerProperties(_: RenderObject): void {
@@ -86,7 +159,15 @@ export class CanvasPaintingContext {
     this.#containerLayer.append(layer);
   }
 
+  /**
+   * Paint a child RenderObject.
+   *
+   * When #skipChildPainting is true (during z-ordered paint phase),
+   * this is a no-op because each painter is invoked individually
+   * in z-order from repaintCompositedChild.
+   */
   paintChild(child: RenderObject, offset: Offset) {
+    if (this.#skipChildPainting) return;
     child.canvasPainter.paint(this, offset);
   }
 }

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -18,6 +18,14 @@ export class CanvasPaintingContext {
   }
   #currentLayer: PictureLayer | null;
 
+  /**
+   * When true, paintChild becomes a no-op. Used during z-ordered
+   * painting so that each painter's performPaint only draws itself
+   * without recursing into children (children are painted separately
+   * in z-order).
+   */
+  #skipChildPainting = false;
+
   static repaintCompositedChild(node: RenderObject): void {
     assert(
       node.canvasPainter.isRepaintBoundary,
@@ -41,8 +49,47 @@ export class CanvasPaintingContext {
       childLayer,
       node.canvasPainter.paintBounds,
     );
-    node.canvasPainter.paint(childContext, Offset.Constants.zero);
+
+    // Phase 1: Collect all painter render objects with their offsets
+    const painters: { renderObject: RenderObject; offset: Offset }[] = [];
+    CanvasPaintingContext.#collectPainters(
+      node,
+      Offset.Constants.zero,
+      painters,
+    );
+
+    // Phase 2: Sort by z-order (calculated by ZOrderCalculatorVisitor)
+    painters.sort((a, b) => a.renderObject.zOrder - b.renderObject.zOrder);
+
+    // Phase 3: Paint each painter in z-order, skipping child traversal
+    childContext.#skipChildPainting = true;
+    for (const { renderObject, offset } of painters) {
+      renderObject.canvasPainter.paint(childContext, offset);
+    }
+    childContext.#skipChildPainting = false;
+
     childContext.stopRecording();
+  }
+
+  /**
+   * Walk the render object tree and collect all painter render objects
+   * with their accumulated offsets.
+   */
+  static #collectPainters(
+    node: RenderObject,
+    offset: Offset,
+    result: { renderObject: RenderObject; offset: Offset }[],
+  ) {
+    if (node.isPainter) {
+      result.push({ renderObject: node, offset });
+    }
+    node.visitChildren(child => {
+      CanvasPaintingContext.#collectPainters(
+        child,
+        offset.plus(child.offset),
+        result,
+      );
+    });
   }
 
   static updateLayerProperties(_: RenderObject): void {
@@ -82,15 +129,14 @@ export class CanvasPaintingContext {
   }
 
   /**
-   * 
-   * @param child   /// Paint a child [RenderObject].
-   * @param offset 
-  ///
-  /// @todo: If the child has its own composited layer, the child will be composited
-  /// into the layer subtree associated with this painting context. Otherwise,
-  /// the child will be painted into the current PictureLayer for this context.
+   * Paint a child RenderObject.
+   *
+   * When #skipChildPainting is true (during z-ordered paint phase),
+   * this is a no-op because each painter is invoked individually
+   * in z-order from repaintCompositedChild.
    */
   paintChild(child: RenderObject, offset: Offset) {
+    if (this.#skipChildPainting) return;
     child.canvasPainter.paint(this, offset);
   }
 }

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -18,14 +18,6 @@ export class CanvasPaintingContext {
   }
   #currentLayer: PictureLayer | null;
 
-  /**
-   * When true, paintChild becomes a no-op. Used during z-ordered
-   * painting so that each painter's performPaint only draws itself
-   * without recursing into children (children are painted separately
-   * in z-order).
-   */
-  #skipChildPainting = false;
-
   static repaintCompositedChild(node: RenderObject): void {
     assert(
       node.canvasPainter.isRepaintBoundary,
@@ -50,46 +42,12 @@ export class CanvasPaintingContext {
       node.canvasPainter.paintBounds,
     );
 
-    // Phase 1: Collect all painter render objects with their offsets
-    const painters: { renderObject: RenderObject; offset: Offset }[] = [];
-    CanvasPaintingContext.#collectPainters(
-      node,
-      Offset.Constants.zero,
-      painters,
-    );
-
-    // Phase 2: Sort by z-order (calculated by ZOrderCalculatorVisitor)
-    painters.sort((a, b) => a.renderObject.zOrder - b.renderObject.zOrder);
-
-    // Phase 3: Paint each painter in z-order, skipping child traversal
-    childContext.#skipChildPainting = true;
-    for (const { renderObject, offset } of painters) {
-      renderObject.canvasPainter.paint(childContext, offset);
-    }
-    childContext.#skipChildPainting = false;
+    // Paint via normal tree walk. Children are sorted by minDescendantZOrder
+    // in CanvasPainter.defaultPaint, so z-ordering is handled naturally
+    // while preserving ancestor canvas state (transforms, clips, opacity).
+    node.canvasPainter.paint(childContext, Offset.Constants.zero);
 
     childContext.stopRecording();
-  }
-
-  /**
-   * Walk the render object tree and collect all painter render objects
-   * with their accumulated offsets.
-   */
-  static #collectPainters(
-    node: RenderObject,
-    offset: Offset,
-    result: { renderObject: RenderObject; offset: Offset }[],
-  ) {
-    if (node.isPainter) {
-      result.push({ renderObject: node, offset });
-    }
-    node.visitChildren(child => {
-      CanvasPaintingContext.#collectPainters(
-        child,
-        offset.plus(child.offset),
-        result,
-      );
-    });
   }
 
   static updateLayerProperties(_: RenderObject): void {
@@ -128,15 +86,7 @@ export class CanvasPaintingContext {
     this.#containerLayer.append(layer);
   }
 
-  /**
-   * Paint a child RenderObject.
-   *
-   * When #skipChildPainting is true (during z-ordered paint phase),
-   * this is a no-op because each painter is invoked individually
-   * in z-order from repaintCompositedChild.
-   */
   paintChild(child: RenderObject, offset: Offset) {
-    if (this.#skipChildPainting) return;
     child.canvasPainter.paint(this, offset);
   }
 }

--- a/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -157,7 +157,13 @@ export class CanvasPaintingContext {
       });
     }
 
-    const childAncestorChain = [...ancestorChain, { node, offset }];
+    // Only non-painter nodes go into the ancestor chain.
+    // Painter nodes (Container, DecoratedBox, etc.) would draw pixels
+    // during ancestor replay, which is undesirable. Non-painter nodes
+    // that modify ctx state (Transform, Opacity) are safely replayed.
+    const childAncestorChain = node.isPainter
+      ? ancestorChain
+      : [...ancestorChain, { node, offset }];
 
     node.visitChildren(child => {
       CanvasPaintingContext.#collectPainters(

--- a/packages/flitter/src/framework/renderer/canvas/canvas-renderer.ts
+++ b/packages/flitter/src/framework/renderer/canvas/canvas-renderer.ts
@@ -9,14 +9,16 @@ export class CanvasRenderPipeline extends RenderPipeline {
   override drawFrame(): void {
     this.flushLayout();
     this.flushPaintTransformUpdate();
-    this.flushPaint();
     this.recalculateZOrder();
+    this.flushPaint();
     this.#compositeFrame();
   }
 
   override reinitializeFrame(): void {
     this.renderView.layout(Constraints.tight(this.renderContext.viewSize));
     this.renderView.updatePaintTransform();
+    this.notifyZOrderChanged();
+    this.recalculateZOrder();
     CanvasPaintingContext.repaintCompositedChild(this.renderView);
     this.#compositeFrame();
   }

--- a/packages/flitter/src/framework/renderer/renderer.ts
+++ b/packages/flitter/src/framework/renderer/renderer.ts
@@ -147,7 +147,20 @@ export abstract class RenderPipeline {
       const renderObject = painterRenderObjects[i];
       renderObject.updateZOrder(i);
     }
+
+    // Compute minDescendantZOrder bottom-up for canvas z-ordered tree walk
+    RenderPipeline.#computeMinDescendantZOrder(this.renderView);
+
     return painterRenderObjects;
+  }
+
+  static #computeMinDescendantZOrder(node: RenderObject): number {
+    let min = node.isPainter ? node.zOrder : Infinity;
+    node.visitChildren(child => {
+      min = Math.min(min, RenderPipeline.#computeMinDescendantZOrder(child));
+    });
+    node.minDescendantZOrder = min === Infinity ? (node.zOrder ?? 0) : min;
+    return node.minDescendantZOrder;
   }
 
   abstract drawFrame(): void;

--- a/packages/flitter/src/renderobject/RenderObject.ts
+++ b/packages/flitter/src/renderobject/RenderObject.ts
@@ -28,6 +28,12 @@ export class RenderObject {
   get zOrder() {
     return this.#zOrder;
   }
+
+  /**
+   * The minimum zOrder among all painter descendants (or own zOrder if painter).
+   * Used by canvas renderer to sort children for z-ordered tree walk painting.
+   */
+  minDescendantZOrder: number = 0;
   updateZOrder(value: number) {
     if (this.#zOrder === value) return;
     this.#zOrder = value;

--- a/packages/story/src/stories/ZIndex/Widget.canvas.stories.ts
+++ b/packages/story/src/stories/ZIndex/Widget.canvas.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import Widget from '../../Widget.svelte';
+import * as Stories from './example/index.js';
+
+const meta = {
+	title: 'Widget/ZIndex/canvas',
+	component: Widget,
+	args: {
+		width: '600px',
+		height: '300px',
+		renderer: 'canvas'
+	}
+} satisfies Meta<Widget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+	args: Stories.Basic
+};
+
+export const Case1: Story = {
+	name: 'Stacking Context/Case1',
+	args: Stories.StackingContext.Case1
+};
+export const Case2: Story = {
+	name: 'Stacking Context/Case2',
+	args: Stories.StackingContext.Case2
+};
+export const Case3: Story = {
+	name: 'Stacking Context/Case3',
+	args: Stories.StackingContext.Case3
+};
+export const Case4: Story = {
+	name: 'Stacking Context/Case4',
+	args: Stories.StackingContext.Case4
+};


### PR DESCRIPTION
## Summary

Closes #43

Add z-index support for canvas rendering, matching SVG behavior including cross-subtree z-ordering and stacking contexts.

## Approach: Flat Collection + Ctx Proxy Replay

SVG uses DOM element reordering for z-index (flat global sort). Canvas cannot reorder draw calls after the fact, so we need a different mechanism that produces the same visual result.

**Solution:**
1. **Flat collection**: Traverse the render tree and collect ALL painter render objects (leaf nodes that draw pixels) with their accumulated offsets
2. **Ancestor chain tracking**: For each painter, record the chain of **non-painter** ancestor render objects that modify canvas state (Transform, Opacity, etc.)
3. **Global z-order sort**: Sort all collected painters by z-order (same values computed by `ZOrderCalculatorVisitor`)
4. **Paint with ctx proxy suppression**: For each painter in z-order:
   - `rawCtx.save()`
   - Replay ancestor chain: call each ancestor's `performPaint` with proxy in suppress mode (outermost save/restore suppressed, so ctx state changes persist)
   - Paint the painter itself (with `skipChildPainting` to prevent recursion)
   - `rawCtx.restore()`

### Transparent Ctx Proxy

`context.canvas` returns a `Proxy` wrapping `CanvasRenderingContext2D` with two modes:
- **Normal mode**: All calls forward directly to real ctx (zero overhead)
- **Suppress mode**: Outermost `save()`/`restore()` are no-ops; all other calls forward normally

This makes z-index orchestration **completely transparent** to widget painters. Transform, ClipPath, Opacity just paint normally with `save → modify → defaultPaint → restore`. The proxy handles state persistence during ancestor replay.

**Why not recording?** Recording commands has a fundamental issue with relative state operations. When Opacity does `ctx.globalAlpha *= 0.5`, the recorded absolute value (0.5) can't be replayed correctly if a parent already changed globalAlpha.

### Ancestor Chain: Non-Painter Only

Only **non-painter** nodes are added to the ancestor chain. Painter nodes (Container, DecoratedBox) would draw pixels during ancestor replay, covering z-indexed children. Non-painter nodes (Transform, Opacity) only modify ctx state, so they are safely replayed via the proxy.

### Why not tree-walk with sibling sorting?

A simpler approach (sorting siblings by `minDescendantZOrder` during tree walk) was tried but **fails cross-subtree z-ordering**. Example: a deeply nested child with `ZIndex(9999)` could not rise above its parent's sibling.

## Changes

| File | Change |
|------|--------|
| `canvas-painting-context.ts` | Add `createCanvasProxy`, flat collection with non-painter ancestor chain, proxy suppress/replay |
| `canvas-painter.ts` | Remove `hasCanvasState`/`applyCanvasState` (no longer needed) |
| `canvas-renderer.ts` | Move `recalculateZOrder()` before `flushPaint()` |
| `renderer.ts` | Compute `minDescendantZOrder` (kept for potential future use) |
| `RenderObject.ts` | Add `minDescendantZOrder` property |
| `BaseTransform.ts` | Remove z-index methods, inline ctx logic in `performPaint` |
| `BaseClipPath.ts` | Remove z-index methods, inline ctx logic in `performPaint` |
| `BaseOpacity.ts` | Remove z-index methods, use standard save/restore pattern |
| `ZIndex/Widget.canvas.stories.ts` | Canvas-specific ZIndex storybook stories |

## Verification

Side-by-side SVG vs Canvas comparison via Playwright MCP:

| Test Case | SVG | Canvas | Match? |
|-----------|-----|--------|--------|
| Basic (cross-subtree z-index) | circle on top of orange | circle on top of orange | ✅ |
| Stacking Context Case1 (ZIndex 0 context) | orange covers circle | orange covers circle | ✅ |
| Stacking Context Case2 (negative z in context) | circle on lightblue | circle on lightblue | ✅ |
| Stacking Context Case3 (negative z, no context) | lightblue only | lightblue only | ✅ |
| Stacking Context Case4 (Transform+ZIndex) | circle above lightblue, behind red | circle above lightblue, behind red | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)