### PR TITLE
Fix RichText hard breaks and inline span layout

### DIFF
--- a/dev/storybook/src/stories/RichText/Widget.stories.tsx
+++ b/dev/storybook/src/stories/RichText/Widget.stories.tsx
@@ -1,171 +1,178 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import DualRenderer from '../../components/DualRenderer';
+import type { Meta, StoryObj } from "@storybook/react";
+import DualRenderer from "../../components/DualRenderer";
 import {
-	TextStyle,
-	Container,
-	Center,
-	RichText,
-	TextSpan,
-	TextAlign,
-	TextWidthBasis,
-	TextOverflow,
-	ConstrainedBox,
-	Constraints
-} from 'flitter-core';
+  TextStyle,
+  Container,
+  Center,
+  RichText,
+  TextSpan,
+  TextAlign,
+  TextWidthBasis,
+  TextOverflow,
+  ConstrainedBox,
+  Constraints,
+} from "flitter-core";
 
 const meta = {
-	title: 'Text/RichText',
-	component: DualRenderer
+  title: "Text/RichText",
+  component: DualRenderer,
 } satisfies Meta<typeof DualRenderer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				child: RichText({ text: new TextSpan({ text: 'Rich Text!!' }) })
-			})
-		})
-	}
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        child: RichText({ text: new TextSpan({ text: "Rich Text!!" }) }),
+      }),
+    }),
+  },
 };
 
 export const WidthChildren: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				child: RichText({
-					text: new TextSpan({
-						text: 'Text1 ',
-						style: new TextStyle({ color: 'white' }),
-						children: [
-							new TextSpan({ text: 'Text2 ', style: new TextStyle({ fontSize: 24 }) }),
-							new TextSpan({ text: 'Text3', style: new TextStyle({ inherit: false }) })
-						]
-					})
-				})
-			})
-		})
-	}
+  name: "With Children",
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        child: RichText({
+          text: new TextSpan({
+            text: "Text1 ",
+            style: new TextStyle({ color: "white" }),
+            children: [
+              new TextSpan({
+                text: "Text2 ",
+                style: new TextStyle({ fontSize: 24 }),
+              }),
+              new TextSpan({
+                text: "Text3",
+                style: new TextStyle({ inherit: false }),
+              }),
+            ],
+          }),
+        }),
+      }),
+    }),
+  },
 };
 
 export const TextAlignCenter: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				width: 300,
-				child: RichText({
-					textAlign: TextAlign.center,
-					text: new TextSpan({ text: 'Align Center' })
-				})
-			})
-		})
-	}
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        width: 300,
+        child: RichText({
+          textAlign: TextAlign.center,
+          text: new TextSpan({ text: "Align Center" }),
+        }),
+      }),
+    }),
+  },
 };
 
 export const MultiLine: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				width: 300,
-				child: ConstrainedBox({
-					constraints: new Constraints({ maxWidth: 300 }),
-					child: RichText({
-						text: new TextSpan({
-							text: '[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AAEp.07 CLEANING'
-						})
-					})
-				})
-			})
-		})
-	}
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        width: 300,
+        child: ConstrainedBox({
+          constraints: new Constraints({ maxWidth: 300 }),
+          child: RichText({
+            text: new TextSpan({
+              text: "[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AAEp.07 CLEANING",
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
 };
 
 export const TextWidthBasisLongestLine: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				child: ConstrainedBox({
-					constraints: new Constraints({ maxWidth: 300 }),
-					child: RichText({
-						textWidthBasis: TextWidthBasis.longestLine,
-						text: new TextSpan({
-							text: '[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AAEp.07 CLEANING'
-						})
-					})
-				})
-			})
-		})
-	}
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        child: ConstrainedBox({
+          constraints: new Constraints({ maxWidth: 300 }),
+          child: RichText({
+            textWidthBasis: TextWidthBasis.longestLine,
+            text: new TextSpan({
+              text: "[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AAEp.07 CLEANING",
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
 };
 
 export const Clipped: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				width: 100,
-				height: 100,
-				child: RichText({
-					overflow: TextOverflow.clip,
-					text: new TextSpan({
-						text: '[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AA\uCCAD\uC18C\uD560 \uB54C \uB4E3\uAE30 \uC88B\uC740 \uBE14\uB8E8\uC2A4 \uD31D \uD50C\uB808\uC774\uB9AC\uC2A4\uD2B8'
-					})
-				})
-			})
-		})
-	}
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        width: 100,
+        height: 100,
+        child: RichText({
+          overflow: TextOverflow.clip,
+          text: new TextSpan({
+            text: "[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AA\uCCAD\uC18C\uD560 \uB54C \uB4E3\uAE30 \uC88B\uC740 \uBE14\uB8E8\uC2A4 \uD31D \uD50C\uB808\uC774\uB9AC\uC2A4\uD2B8",
+          }),
+        }),
+      }),
+    }),
+  },
 };
 
 export const NoWrapped: Story = {
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				width: 300,
-				child: RichText({
-					softWrap: false,
-					text: new TextSpan({
-						text: '[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AA\uCCAD\uC18C\uD560 \uB54C \uB4E3\uAE30 \uC88B\uC740 \uBE14\uB8E8\uC2A4 \uD31D \uD50C\uB808\uC774\uB9AC\uC2A4\uD2B8'
-					})
-				})
-			})
-		})
-	}
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        width: 300,
+        child: RichText({
+          softWrap: false,
+          text: new TextSpan({
+            text: "[PLAYLIST] EP.07 CLEANING BLUES POP PLAYLIST\u23AA\uCCAD\uC18C\uD560 \uB54C \uB4E3\uAE30 \uC88B\uC740 \uBE14\uB8E8\uC2A4 \uD31D \uD50C\uB808\uC774\uB9AC\uC2A4\uD2B8",
+          }),
+        }),
+      }),
+    }),
+  },
 };
 
 export const LineChangeAtN: Story = {
-	name: 'Line Change At \\n',
-	args: {
-		width: '600px',
-		height: '300px',
-		widget: Center({
-			child: Container({
-				color: 'orange',
-				child: RichText({
-					text: new TextSpan({ text: 'Hello\nLine Changed!!' })
-				})
-			})
-		})
-	}
+  name: "Line Change At \\n",
+  args: {
+    width: "600px",
+    height: "300px",
+    widget: Center({
+      child: Container({
+        color: "orange",
+        child: RichText({
+          text: new TextSpan({ text: "Hello\nLine Changed!!" }),
+        }),
+      }),
+    }),
+  },
 };

--- a/packages/core/src/type/_types/text-painter/analysis.ts
+++ b/packages/core/src/type/_types/text-painter/analysis.ts
@@ -4,7 +4,7 @@
 //
 // Adapted for Flitter's SSR-safe environment.
 
-export type WhiteSpaceMode = "normal" | "pre-wrap";
+export type WhiteSpaceMode = "normal" | "pre-line" | "pre-wrap";
 export type WordBreakMode = "normal" | "keep-all";
 
 export type SegmentBreakKind =
@@ -38,14 +38,19 @@ export type AnalysisChunk = {
   consumedEndSegmentIndex: number;
 };
 
-export type TextAnalysis = { normalized: string; chunks: AnalysisChunk[] } & MergedSegmentation;
+export type TextAnalysis = {
+  normalized: string;
+  chunks: AnalysisChunk[];
+} & MergedSegmentation;
 
 export type AnalysisProfile = {
   carryCJKAfterClosingQuote: boolean;
 };
 
 const collapsibleWhitespaceRunRe = /[ \t\n\r\f]+/g;
+const collapsibleWhitespaceWithoutHardBreaksRunRe = /[ \t\r\f]+/g;
 const needsWhitespaceNormalizationRe = /[\t\n\r\f]| {2,}|^ | $/;
+const needsWhitespaceNormalizationWithHardBreaksRe = /[\t\n\r\f]| {2,}|^ | $/;
 
 type WhiteSpaceProfile = {
   mode: WhiteSpaceMode;
@@ -55,22 +60,48 @@ type WhiteSpaceProfile = {
 
 function getWhiteSpaceProfile(whiteSpace?: WhiteSpaceMode): WhiteSpaceProfile {
   const mode = whiteSpace ?? "normal";
-  return mode === "pre-wrap"
-    ? { mode, preserveOrdinarySpaces: true, preserveHardBreaks: true }
-    : { mode, preserveOrdinarySpaces: false, preserveHardBreaks: false };
+  switch (mode) {
+    case "pre-wrap":
+      return { mode, preserveOrdinarySpaces: true, preserveHardBreaks: true };
+    case "pre-line":
+      return { mode, preserveOrdinarySpaces: false, preserveHardBreaks: true };
+    default:
+      return { mode, preserveOrdinarySpaces: false, preserveHardBreaks: false };
+  }
+}
+
+function trimCollapsedEdges(text: string): string {
+  let normalized = text;
+  if (normalized.charCodeAt(0) === 0x20) {
+    normalized = normalized.slice(1);
+  }
+  if (
+    normalized.length > 0 &&
+    normalized.charCodeAt(normalized.length - 1) === 0x20
+  ) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
 }
 
 export function normalizeWhitespaceNormal(text: string): string {
   if (!needsWhitespaceNormalizationRe.test(text)) return text;
 
-  let normalized = text.replace(collapsibleWhitespaceRunRe, " ");
-  if (normalized.charCodeAt(0) === 0x20) {
-    normalized = normalized.slice(1);
-  }
-  if (normalized.length > 0 && normalized.charCodeAt(normalized.length - 1) === 0x20) {
-    normalized = normalized.slice(0, -1);
-  }
-  return normalized;
+  return trimCollapsedEdges(text.replace(collapsibleWhitespaceRunRe, " "));
+}
+
+function normalizeWhitespacePreLine(text: string): string {
+  if (!needsWhitespaceNormalizationWithHardBreaksRe.test(text)) return text;
+
+  const normalizedBreaks = text.replace(/\r\n/g, "\n").replace(/[\r\f]/g, "\n");
+  return normalizedBreaks
+    .split("\n")
+    .map(line =>
+      trimCollapsedEdges(
+        line.replace(collapsibleWhitespaceWithoutHardBreaksRunRe, " "),
+      ),
+    )
+    .join("\n");
 }
 
 function normalizeWhitespacePreWrap(text: string): string {
@@ -83,7 +114,9 @@ let segmenterLocale: string | undefined;
 
 function getSharedWordSegmenter(): Intl.Segmenter {
   if (sharedWordSegmenter === null) {
-    sharedWordSegmenter = new Intl.Segmenter(segmenterLocale, { granularity: "word" });
+    sharedWordSegmenter = new Intl.Segmenter(segmenterLocale, {
+      granularity: "word",
+    });
   }
   return sharedWordSegmenter;
 }
@@ -138,7 +171,8 @@ export function isCJK(s: string): boolean {
     if (first >= 0xd800 && first <= 0xdbff && i + 1 < s.length) {
       const second = s.charCodeAt(i + 1);
       if (second >= 0xdc00 && second <= 0xdfff) {
-        const codePoint = ((first - 0xd800) << 10) + (second - 0xdc00) + 0x10000;
+        const codePoint =
+          ((first - 0xd800) << 10) + (second - 0xdc00) + 0x10000;
         if (isCJKCodePoint(codePoint)) return true;
         i++;
         continue;
@@ -152,7 +186,9 @@ export function isCJK(s: string): boolean {
 
 function endsWithLineStartProhibitedText(text: string): boolean {
   const last = getLastCodePoint(text);
-  return last !== null && (kinsokuStart.has(last) || leftStickyPunctuation.has(last));
+  return (
+    last !== null && (kinsokuStart.has(last) || leftStickyPunctuation.has(last))
+  );
 }
 
 const keepAllGlueChars = new Set(["\u00a0", "\u202f", "\u2060", "\ufeff"]);
@@ -170,41 +206,107 @@ export function canContinueKeepAllTextRun(previousText: string): boolean {
 }
 
 export const kinsokuStart = new Set([
-  "\uff0c", "\uff0e", "\uff01", "\uff1a", "\uff1b", "\uff1f",
-  "\u3001", "\u3002", "\u30fb",
-  "\uff09", "\u3015", "\u3009", "\u300b", "\u300d", "\u300f",
-  "\u3011", "\u3017", "\u3019", "\u301b",
-  "\u30fc", "\u3005", "\u303b", "\u309d", "\u309e", "\u30fd", "\u30fe",
+  "\uff0c",
+  "\uff0e",
+  "\uff01",
+  "\uff1a",
+  "\uff1b",
+  "\uff1f",
+  "\u3001",
+  "\u3002",
+  "\u30fb",
+  "\uff09",
+  "\u3015",
+  "\u3009",
+  "\u300b",
+  "\u300d",
+  "\u300f",
+  "\u3011",
+  "\u3017",
+  "\u3019",
+  "\u301b",
+  "\u30fc",
+  "\u3005",
+  "\u303b",
+  "\u309d",
+  "\u309e",
+  "\u30fd",
+  "\u30fe",
 ]);
 
 export const kinsokuEnd = new Set([
-  '"', "(", "[", "{",
-  "\u201c", "\u2018", "\u00ab", "\u2039",
-  "\uff08", "\u3014", "\u3008", "\u300a", "\u300c", "\u300e",
-  "\u3010", "\u3016", "\u3018", "\u301a",
+  '"',
+  "(",
+  "[",
+  "{",
+  "\u201c",
+  "\u2018",
+  "\u00ab",
+  "\u2039",
+  "\uff08",
+  "\u3014",
+  "\u3008",
+  "\u300a",
+  "\u300c",
+  "\u300e",
+  "\u3010",
+  "\u3016",
+  "\u3018",
+  "\u301a",
 ]);
 
 const forwardStickyGlue = new Set(["'", "\u2019"]);
 
 export const leftStickyPunctuation = new Set([
-  ".", ",", "!", "?", ":", ";",
-  "\u060c", "\u061b", "\u061f",
-  "\u0964", "\u0965",
-  "\u104a", "\u104b", "\u104c", "\u104d", "\u104f",
-  ")", "]", "}", "%", '"',
-  "\u201d", "\u2019", "\u00bb", "\u203a",
+  ".",
+  ",",
+  "!",
+  "?",
+  ":",
+  ";",
+  "\u060c",
+  "\u061b",
+  "\u061f",
+  "\u0964",
+  "\u0965",
+  "\u104a",
+  "\u104b",
+  "\u104c",
+  "\u104d",
+  "\u104f",
+  ")",
+  "]",
+  "}",
+  "%",
+  '"',
+  "\u201d",
+  "\u2019",
+  "\u00bb",
+  "\u203a",
   "\u2026",
 ]);
 
 const arabicNoSpaceTrailingPunctuation = new Set([
-  ":", ".", "\u060c", "\u061b",
+  ":",
+  ".",
+  "\u060c",
+  "\u061b",
 ]);
 
 const myanmarMedialGlue = new Set(["\u104f"]);
 
 const closingQuoteChars = new Set([
-  "\u201d", "\u2019", "\u00bb", "\u203a",
-  "\u300d", "\u300f", "\u3011", "\u300b", "\u3009", "\u3015", "\uff09",
+  "\u201d",
+  "\u2019",
+  "\u00bb",
+  "\u203a",
+  "\u300d",
+  "\u300f",
+  "\u3011",
+  "\u300b",
+  "\u3009",
+  "\u3015",
+  "\uff09",
 ]);
 
 function isLeftStickyPunctuationSegment(segment: string): boolean {
@@ -231,7 +333,12 @@ function isCJKLineStartProhibitedSegment(segment: string): boolean {
 function isForwardStickyClusterSegment(segment: string): boolean {
   if (isEscapedQuoteClusterSegment(segment)) return true;
   for (const ch of segment) {
-    if (!kinsokuEnd.has(ch) && !forwardStickyGlue.has(ch) && !combiningMarkRe.test(ch)) return false;
+    if (
+      !kinsokuEnd.has(ch) &&
+      !forwardStickyGlue.has(ch) &&
+      !combiningMarkRe.test(ch)
+    )
+      return false;
   }
   return segment.length > 0;
 }
@@ -240,7 +347,11 @@ function isEscapedQuoteClusterSegment(segment: string): boolean {
   let sawQuote = false;
   for (const ch of segment) {
     if (ch === "\\" || combiningMarkRe.test(ch)) continue;
-    if (kinsokuEnd.has(ch) || leftStickyPunctuation.has(ch) || forwardStickyGlue.has(ch)) {
+    if (
+      kinsokuEnd.has(ch) ||
+      leftStickyPunctuation.has(ch) ||
+      forwardStickyGlue.has(ch)
+    ) {
       sawQuote = true;
       continue;
     }
@@ -269,7 +380,9 @@ function getLastCodePoint(text: string): string | null {
   return text.slice(start);
 }
 
-function splitTrailingForwardStickyCluster(text: string): { head: string; tail: string } | null {
+function splitTrailingForwardStickyCluster(
+  text: string,
+): { head: string; tail: string } | null {
   const chars = Array.from(text);
   let splitIndex = chars.length;
 
@@ -298,7 +411,11 @@ function getRepeatableSingleCharRunChar(
   isWordLike: boolean,
   kind: SegmentBreakKind,
 ): string | null {
-  return kind === "text" && !isWordLike && text.length === 1 && text !== "-" && text !== "\u2014"
+  return kind === "text" &&
+    !isWordLike &&
+    text.length === 1 &&
+    text !== "-" &&
+    text !== "\u2014"
     ? text
     : null;
 }
@@ -325,7 +442,11 @@ function hasArabicNoSpacePunctuation(
   containsArabic: boolean,
   lastCodePoint: string | null,
 ): boolean {
-  return containsArabic && lastCodePoint !== null && arabicNoSpaceTrailingPunctuation.has(lastCodePoint);
+  return (
+    containsArabic &&
+    lastCodePoint !== null &&
+    arabicNoSpaceTrailingPunctuation.has(lastCodePoint)
+  );
 }
 
 function endsWithMyanmarMedialGlue(segment: string): boolean {
@@ -333,7 +454,9 @@ function endsWithMyanmarMedialGlue(segment: string): boolean {
   return lastCodePoint !== null && myanmarMedialGlue.has(lastCodePoint);
 }
 
-function splitLeadingSpaceAndMarks(segment: string): { space: string; marks: string } | null {
+function splitLeadingSpaceAndMarks(
+  segment: string,
+): { space: string; marks: string } | null {
   if (segment.length < 2 || segment[0] !== " ") return null;
   const marks = segment.slice(1);
   if (/^\p{M}+$/u.test(marks)) {
@@ -354,14 +477,22 @@ export function endsWithClosingQuote(text: string): boolean {
   return false;
 }
 
-function classifySegmentBreakChar(ch: string, whiteSpaceProfile: WhiteSpaceProfile): SegmentBreakKind {
-  if (whiteSpaceProfile.preserveOrdinarySpaces || whiteSpaceProfile.preserveHardBreaks) {
+function classifySegmentBreakChar(
+  ch: string,
+  whiteSpaceProfile: WhiteSpaceProfile,
+): SegmentBreakKind {
+  if (whiteSpaceProfile.preserveOrdinarySpaces) {
     if (ch === " ") return "preserved-space";
     if (ch === "\t") return "tab";
-    if (whiteSpaceProfile.preserveHardBreaks && ch === "\n") return "hard-break";
   }
+  if (whiteSpaceProfile.preserveHardBreaks && ch === "\n") return "hard-break";
   if (ch === " ") return "space";
-  if (ch === "\u00a0" || ch === "\u202f" || ch === "\u2060" || ch === "\ufeff") {
+  if (
+    ch === "\u00a0" ||
+    ch === "\u202f" ||
+    ch === "\u2060" ||
+    ch === "\ufeff"
+  ) {
     return "glue";
   }
   if (ch === "\u200b") return "zero-width-break";
@@ -405,7 +536,11 @@ function splitSegmentByBreakKind(
     const kind = classifySegmentBreakChar(ch, whiteSpaceProfile);
     const wordLike = kind === "text" && isWordLike;
 
-    if (currentKind !== null && kind === currentKind && wordLike === currentWordLike) {
+    if (
+      currentKind !== null &&
+      kind === currentKind &&
+      wordLike === currentWordLike
+    ) {
       currentTextParts.push(ch);
       offset += ch.length;
       continue;
@@ -450,7 +585,10 @@ function isTextRunBoundary(kind: SegmentBreakKind): boolean {
 
 const urlSchemeSegmentRe = /^[A-Za-z][A-Za-z0-9+.-]*:$/;
 
-function isUrlLikeRunStart(segmentation: MergedSegmentation, index: number): boolean {
+function isUrlLikeRunStart(
+  segmentation: MergedSegmentation,
+  index: number,
+): boolean {
   const text = segmentation.texts[index]!;
   if (text.startsWith("www.")) return true;
   return (
@@ -462,10 +600,14 @@ function isUrlLikeRunStart(segmentation: MergedSegmentation, index: number): boo
 }
 
 function isUrlQueryBoundarySegment(text: string): boolean {
-  return text.includes("?") && (text.includes("://") || text.startsWith("www."));
+  return (
+    text.includes("?") && (text.includes("://") || text.startsWith("www."))
+  );
 }
 
-function mergeUrlLikeRuns(segmentation: MergedSegmentation): MergedSegmentation {
+function mergeUrlLikeRuns(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts = segmentation.texts.slice();
   const isWordLike = segmentation.isWordLike.slice();
   const kinds = segmentation.kinds.slice();
@@ -509,7 +651,9 @@ function mergeUrlLikeRuns(segmentation: MergedSegmentation): MergedSegmentation 
   return { len: compactLen, texts, isWordLike, kinds, starts };
 }
 
-function mergeUrlQueryRuns(segmentation: MergedSegmentation): MergedSegmentation {
+function mergeUrlQueryRuns(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts: string[] = [];
   const isWordLike: boolean[] = [];
   const kinds: SegmentBreakKind[] = [];
@@ -553,7 +697,15 @@ function mergeUrlQueryRuns(segmentation: MergedSegmentation): MergedSegmentation
 }
 
 const numericJoinerChars = new Set([
-  ":", "-", "/", "\u00d7", ",", ".", "+", "\u2013", "\u2014",
+  ":",
+  "-",
+  "/",
+  "\u00d7",
+  ",",
+  ".",
+  "+",
+  "\u2013",
+  "\u2014",
 ]);
 
 const asciiPunctuationChainSegmentRe = /^[A-Za-z0-9_]+[,:;]*$/;
@@ -575,7 +727,9 @@ export function isNumericRunSegment(text: string): boolean {
   return true;
 }
 
-function mergeNumericRuns(segmentation: MergedSegmentation): MergedSegmentation {
+function mergeNumericRuns(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts: string[] = [];
   const isWordLike: boolean[] = [];
   const kinds: SegmentBreakKind[] = [];
@@ -585,7 +739,11 @@ function mergeNumericRuns(segmentation: MergedSegmentation): MergedSegmentation 
     const text = segmentation.texts[i]!;
     const kind = segmentation.kinds[i]!;
 
-    if (kind === "text" && isNumericRunSegment(text) && segmentContainsDecimalDigit(text)) {
+    if (
+      kind === "text" &&
+      isNumericRunSegment(text) &&
+      segmentContainsDecimalDigit(text)
+    ) {
       const mergedParts = [text];
       let j = i + 1;
       while (
@@ -614,7 +772,9 @@ function mergeNumericRuns(segmentation: MergedSegmentation): MergedSegmentation 
   return { len: texts.length, texts, isWordLike, kinds, starts };
 }
 
-function mergeAsciiPunctuationChains(segmentation: MergedSegmentation): MergedSegmentation {
+function mergeAsciiPunctuationChains(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts: string[] = [];
   const isWordLike: boolean[] = [];
   const kinds: SegmentBreakKind[] = [];
@@ -625,7 +785,11 @@ function mergeAsciiPunctuationChains(segmentation: MergedSegmentation): MergedSe
     const kind = segmentation.kinds[i]!;
     const wordLike = segmentation.isWordLike[i]!;
 
-    if (kind === "text" && wordLike && asciiPunctuationChainSegmentRe.test(text)) {
+    if (
+      kind === "text" &&
+      wordLike &&
+      asciiPunctuationChainSegmentRe.test(text)
+    ) {
       const mergedParts = [text];
       let endsWithJoiners = asciiPunctuationChainTrailingJoinersRe.test(text);
       let j = i + 1;
@@ -660,7 +824,9 @@ function mergeAsciiPunctuationChains(segmentation: MergedSegmentation): MergedSe
   return { len: texts.length, texts, isWordLike, kinds, starts };
 }
 
-function splitHyphenatedNumericRuns(segmentation: MergedSegmentation): MergedSegmentation {
+function splitHyphenatedNumericRuns(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts: string[] = [];
   const isWordLike: boolean[] = [];
   const kinds: SegmentBreakKind[] = [];
@@ -707,7 +873,9 @@ function splitHyphenatedNumericRuns(segmentation: MergedSegmentation): MergedSeg
   return { len: texts.length, texts, isWordLike, kinds, starts };
 }
 
-function mergeGlueConnectedTextRuns(segmentation: MergedSegmentation): MergedSegmentation {
+function mergeGlueConnectedTextRuns(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts: string[] = [];
   const isWordLike: boolean[] = [];
   const kinds: SegmentBreakKind[] = [];
@@ -777,7 +945,9 @@ function mergeGlueConnectedTextRuns(segmentation: MergedSegmentation): MergedSeg
   return { len: texts.length, texts, isWordLike, kinds, starts };
 }
 
-function carryTrailingForwardStickyAcrossCJKBoundary(segmentation: MergedSegmentation): MergedSegmentation {
+function carryTrailingForwardStickyAcrossCJKBoundary(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   const texts = segmentation.texts.slice();
   const isWordLike = segmentation.isWordLike.slice();
   const kinds = segmentation.kinds.slice();
@@ -819,14 +989,25 @@ function buildMergedSegmentation(
   const mergedHasArabicNoSpacePunctuation: boolean[] = [];
 
   for (const s of wordSegmenter.segment(normalized)) {
-    for (const piece of splitSegmentByBreakKind(s.segment, s.isWordLike ?? false, s.index, whiteSpaceProfile)) {
+    for (const piece of splitSegmentByBreakKind(
+      s.segment,
+      s.isWordLike ?? false,
+      s.index,
+      whiteSpaceProfile,
+    )) {
       const isText = piece.kind === "text";
-      const repeatableSingleCharRunChar = getRepeatableSingleCharRunChar(piece.text, piece.isWordLike, piece.kind);
+      const repeatableSingleCharRunChar = getRepeatableSingleCharRunChar(
+        piece.text,
+        piece.isWordLike,
+        piece.kind,
+      );
       const pieceContainsCJK = isCJK(piece.text);
       const pieceContainsArabicScript = containsArabicScript(piece.text);
       const pieceLastCodePoint = getLastCodePoint(piece.text);
       const pieceEndsWithClosingQuote = endsWithClosingQuote(piece.text);
-      const pieceEndsWithMyanmarMedialGlue = endsWithMyanmarMedialGlue(piece.text);
+      const pieceEndsWithMyanmarMedialGlue = endsWithMyanmarMedialGlue(
+        piece.text,
+      );
       const prevIndex = mergedLen - 1;
 
       function appendPieceToPrevious(): void {
@@ -842,16 +1023,20 @@ function buildMergedSegmentation(
           mergedSingleCharRunChars[prevIndex] = null;
         }
         mergedTextParts[prevIndex]!.push(piece.text);
-        mergedWordLike[prevIndex] = mergedWordLike[prevIndex]! || piece.isWordLike;
-        mergedContainsCJK[prevIndex] = mergedContainsCJK[prevIndex]! || pieceContainsCJK;
+        mergedWordLike[prevIndex] =
+          mergedWordLike[prevIndex]! || piece.isWordLike;
+        mergedContainsCJK[prevIndex] =
+          mergedContainsCJK[prevIndex]! || pieceContainsCJK;
         mergedContainsArabicScript[prevIndex] =
           mergedContainsArabicScript[prevIndex]! || pieceContainsArabicScript;
         mergedEndsWithClosingQuote[prevIndex] = pieceEndsWithClosingQuote;
-        mergedEndsWithMyanmarMedialGlue[prevIndex] = pieceEndsWithMyanmarMedialGlue;
-        mergedHasArabicNoSpacePunctuation[prevIndex] = hasArabicNoSpacePunctuation(
-          mergedContainsArabicScript[prevIndex]!,
-          pieceLastCodePoint,
-        );
+        mergedEndsWithMyanmarMedialGlue[prevIndex] =
+          pieceEndsWithMyanmarMedialGlue;
+        mergedHasArabicNoSpacePunctuation[prevIndex] =
+          hasArabicNoSpacePunctuation(
+            mergedContainsArabicScript[prevIndex]!,
+            pieceLastCodePoint,
+          );
       }
 
       if (
@@ -895,7 +1080,8 @@ function buildMergedSegmentation(
         mergedKinds[prevIndex] === "text" &&
         mergedSingleCharRunChars[prevIndex] === repeatableSingleCharRunChar
       ) {
-        mergedSingleCharRunLengths[prevIndex] = (mergedSingleCharRunLengths[prevIndex] ?? 1) + 1;
+        mergedSingleCharRunLengths[prevIndex] =
+          (mergedSingleCharRunLengths[prevIndex] ?? 1) + 1;
       } else if (
         isText &&
         !piece.isWordLike &&
@@ -912,15 +1098,18 @@ function buildMergedSegmentation(
         mergedKinds[mergedLen] = piece.kind;
         mergedStarts[mergedLen] = piece.start;
         mergedSingleCharRunChars[mergedLen] = repeatableSingleCharRunChar;
-        mergedSingleCharRunLengths[mergedLen] = repeatableSingleCharRunChar === null ? 0 : 1;
+        mergedSingleCharRunLengths[mergedLen] =
+          repeatableSingleCharRunChar === null ? 0 : 1;
         mergedContainsCJK[mergedLen] = pieceContainsCJK;
         mergedContainsArabicScript[mergedLen] = pieceContainsArabicScript;
         mergedEndsWithClosingQuote[mergedLen] = pieceEndsWithClosingQuote;
-        mergedEndsWithMyanmarMedialGlue[mergedLen] = pieceEndsWithMyanmarMedialGlue;
-        mergedHasArabicNoSpacePunctuation[mergedLen] = hasArabicNoSpacePunctuation(
-          pieceContainsArabicScript,
-          pieceLastCodePoint,
-        );
+        mergedEndsWithMyanmarMedialGlue[mergedLen] =
+          pieceEndsWithMyanmarMedialGlue;
+        mergedHasArabicNoSpacePunctuation[mergedLen] =
+          hasArabicNoSpacePunctuation(
+            pieceContainsArabicScript,
+            pieceLastCodePoint,
+          );
         mergedLen++;
       }
     }
@@ -953,7 +1142,10 @@ function buildMergedSegmentation(
     }
   }
 
-  const forwardStickyPrefixParts: (string[] | null)[] = Array.from({ length: mergedLen }, () => null);
+  const forwardStickyPrefixParts: (string[] | null)[] = Array.from(
+    { length: mergedLen },
+    () => null,
+  );
   let nextLiveIndex = -1;
 
   for (let i = mergedLen - 1; i >= 0; i--) {
@@ -1011,7 +1203,9 @@ function buildMergedSegmentation(
   });
   const withMergedUrls = carryTrailingForwardStickyAcrossCJKBoundary(
     mergeAsciiPunctuationChains(
-      splitHyphenatedNumericRuns(mergeNumericRuns(mergeUrlQueryRuns(mergeUrlLikeRuns(compacted)))),
+      splitHyphenatedNumericRuns(
+        mergeNumericRuns(mergeUrlQueryRuns(mergeUrlLikeRuns(compacted))),
+      ),
     ),
   );
 
@@ -1020,7 +1214,8 @@ function buildMergedSegmentation(
     const split = splitLeadingSpaceAndMarks(withMergedUrls.texts[i]!);
     if (split === null) continue;
     if (
-      (withMergedUrls.kinds[i] !== "space" && withMergedUrls.kinds[i] !== "preserved-space") ||
+      (withMergedUrls.kinds[i] !== "space" &&
+        withMergedUrls.kinds[i] !== "preserved-space") ||
       withMergedUrls.kinds[i + 1] !== "text" ||
       !containsArabicScript(withMergedUrls.texts[i + 1]!)
     ) {
@@ -1029,22 +1224,31 @@ function buildMergedSegmentation(
 
     withMergedUrls.texts[i] = split.space;
     withMergedUrls.isWordLike[i] = false;
-    withMergedUrls.kinds[i] = withMergedUrls.kinds[i] === "preserved-space" ? "preserved-space" : "space";
+    withMergedUrls.kinds[i] =
+      withMergedUrls.kinds[i] === "preserved-space"
+        ? "preserved-space"
+        : "space";
     withMergedUrls.texts[i + 1] = split.marks + withMergedUrls.texts[i + 1]!;
-    withMergedUrls.starts[i + 1] = withMergedUrls.starts[i]! + split.space.length;
+    withMergedUrls.starts[i + 1] =
+      withMergedUrls.starts[i]! + split.space.length;
   }
 
   return withMergedUrls;
 }
 
-function compileAnalysisChunks(segmentation: MergedSegmentation, whiteSpaceProfile: WhiteSpaceProfile): AnalysisChunk[] {
+function compileAnalysisChunks(
+  segmentation: MergedSegmentation,
+  whiteSpaceProfile: WhiteSpaceProfile,
+): AnalysisChunk[] {
   if (segmentation.len === 0) return [];
   if (!whiteSpaceProfile.preserveHardBreaks) {
-    return [{
-      startSegmentIndex: 0,
-      endSegmentIndex: segmentation.len,
-      consumedEndSegmentIndex: segmentation.len,
-    }];
+    return [
+      {
+        startSegmentIndex: 0,
+        endSegmentIndex: segmentation.len,
+        consumedEndSegmentIndex: segmentation.len,
+      },
+    ];
   }
 
   const chunks: AnalysisChunk[] = [];
@@ -1072,7 +1276,9 @@ function compileAnalysisChunks(segmentation: MergedSegmentation, whiteSpaceProfi
   return chunks;
 }
 
-function mergeKeepAllTextSegments(segmentation: MergedSegmentation): MergedSegmentation {
+function mergeKeepAllTextSegments(
+  segmentation: MergedSegmentation,
+): MergedSegmentation {
   if (segmentation.len <= 1) return segmentation;
 
   const texts: string[] = [];
@@ -1105,7 +1311,11 @@ function mergeKeepAllTextSegments(segmentation: MergedSegmentation): MergedSegme
       const textContainsCJK = isCJK(text);
       const textCanContinue = canContinueKeepAllTextRun(text);
 
-      if (pendingTextParts !== null && pendingContainsCJK && pendingCanContinue) {
+      if (
+        pendingTextParts !== null &&
+        pendingContainsCJK &&
+        pendingCanContinue
+      ) {
         pendingTextParts.push(text);
         pendingWordLike = pendingWordLike || wordLike;
         pendingContainsCJK = pendingContainsCJK || textContainsCJK;
@@ -1141,9 +1351,12 @@ export function analyzeText(
   wordBreak: WordBreakMode = "normal",
 ): TextAnalysis {
   const whiteSpaceProfile = getWhiteSpaceProfile(whiteSpace);
-  const normalized = whiteSpaceProfile.mode === "pre-wrap"
-    ? normalizeWhitespacePreWrap(text)
-    : normalizeWhitespaceNormal(text);
+  const normalized =
+    whiteSpaceProfile.mode === "pre-wrap"
+      ? normalizeWhitespacePreWrap(text)
+      : whiteSpaceProfile.mode === "pre-line"
+        ? normalizeWhitespacePreLine(text)
+        : normalizeWhitespaceNormal(text);
   if (normalized.length === 0) {
     return {
       normalized,
@@ -1155,9 +1368,12 @@ export function analyzeText(
       starts: [],
     };
   }
-  const segmentation = wordBreak === "keep-all"
-    ? mergeKeepAllTextSegments(buildMergedSegmentation(normalized, profile, whiteSpaceProfile))
-    : buildMergedSegmentation(normalized, profile, whiteSpaceProfile);
+  const segmentation =
+    wordBreak === "keep-all"
+      ? mergeKeepAllTextSegments(
+          buildMergedSegmentation(normalized, profile, whiteSpaceProfile),
+        )
+      : buildMergedSegmentation(normalized, profile, whiteSpaceProfile);
   return {
     normalized,
     chunks: compileAnalysisChunks(segmentation, whiteSpaceProfile),

--- a/packages/core/src/type/_types/text-painter/index.ts
+++ b/packages/core/src/type/_types/text-painter/index.ts
@@ -1,5 +1,9 @@
 import type InlineSpan from "../Inline-span";
-import Utils, { assert, getPooledFontString, getTextWidth } from "../../../utils";
+import Utils, {
+  assert,
+  getPooledFontString,
+  getTextWidth,
+} from "../../../utils";
 import type { SvgPaintContext } from "../../../framework";
 import type Offset from "../_offset";
 import { TextDirection, TextAlign, TextWidthBasis } from "../..";
@@ -10,10 +14,7 @@ import {
   type MeasuredSpanResult,
 } from "./layout";
 import type { PreparedLineBreakData } from "./line-break";
-import {
-  walkPreparedLines,
-  type InternalLayoutLine,
-} from "./line-break";
+import { walkPreparedLines, type InternalLayoutLine } from "./line-break";
 import type { SegmentBreakKind } from "./analysis";
 
 function getTextHeight({ fontSize }: { fontSize: number }) {
@@ -403,7 +404,8 @@ export class Paragraph {
       }
     });
 
-    const isTruncated = layoutLines.length >= maxLineCount &&
+    const isTruncated =
+      layoutLines.length >= maxLineCount &&
       this.hasMoreContentAfterLine(layoutLines[layoutLines.length - 1]);
 
     // Convert InternalLayoutLines to ParagraphLines with SpanBoxes
@@ -713,10 +715,14 @@ export class Paragraph {
     return this.lines.length - 1;
   }
 
-  private hasMoreContentAfterLine(line: InternalLayoutLine | undefined): boolean {
+  private hasMoreContentAfterLine(
+    line: InternalLayoutLine | undefined,
+  ): boolean {
     if (line == null || this.preparedLineBreakData == null) return false;
-    return line.endSegmentIndex < this.preparedLineBreakData.widths.length ||
-      line.endGraphemeIndex > 0;
+    return (
+      line.endSegmentIndex < this.preparedLineBreakData.widths.length ||
+      line.endGraphemeIndex > 0
+    );
   }
 
   /**
@@ -728,13 +734,15 @@ export class Paragraph {
     const endSegIdx = layoutLine.endSegmentIndex;
 
     // Determine default style from the first segment in this line
-    const defaultStyle = startSegIdx < this.preparedSegmentInfos.length
-      ? this.preparedSegmentInfos[startSegIdx]!.style
-      : this.defaultLineStyle;
+    const defaultStyle =
+      startSegIdx < this.preparedSegmentInfos.length
+        ? this.preparedSegmentInfos[startSegIdx]!.style
+        : this.defaultLineStyle;
 
-    const startOffset = startSegIdx < this.preparedSegmentInfos.length
-      ? this.preparedSegmentInfos[startSegIdx]!.charStart
-      : this.preparedTextLength;
+    const startOffset =
+      startSegIdx < this.preparedSegmentInfos.length
+        ? this.preparedSegmentInfos[startSegIdx]!.charStart
+        : this.preparedTextLength;
 
     const paragraphLine = new ParagraphLine({
       defaultStyle,
@@ -778,7 +786,10 @@ export class Paragraph {
       }
 
       // Style change — flush group
-      if (info.style.font !== groupStyle.font || info.style.color !== groupStyle.color) {
+      if (
+        info.style.font !== groupStyle.font ||
+        info.style.color !== groupStyle.color
+      ) {
         if (i > groupStart) {
           const spanBox = this.buildSpanBoxForRange(
             groupStart,
@@ -846,7 +857,11 @@ export class Paragraph {
       const segWidth = widths[i] ?? 0;
 
       // Handle partial first segment (startGrapheme > 0)
-      if (i === startSeg && startGrapheme > 0 && breakableFitAdvances[i] != null) {
+      if (
+        i === startSeg &&
+        startGrapheme > 0 &&
+        breakableFitAdvances[i] != null
+      ) {
         const fitAdvances = breakableFitAdvances[i]!;
         // Build partial content from graphemes
         const graphemes = this.getSegmentGraphemes(segText);
@@ -860,19 +875,28 @@ export class Paragraph {
         }
         content += partialText;
         totalWidth += partialWidth;
-        charStart = info.charStart + this.graphemeOffset(segText, startGrapheme);
+        charStart =
+          info.charStart + this.graphemeOffset(segText, startGrapheme);
         charEnd = info.charEnd;
         continue;
       }
 
       // Handle partial last segment (endGrapheme > 0)
-      if (i === endSeg - 1 && endGrapheme > 0 && breakableFitAdvances[i] != null) {
+      if (
+        i === endSeg - 1 &&
+        endGrapheme > 0 &&
+        breakableFitAdvances[i] != null
+      ) {
         const fitAdvances = breakableFitAdvances[i]!;
         const graphemes = this.getSegmentGraphemes(segText);
         let partialText = "";
         let partialWidth = 0;
-        const graphemeStart = (i === startSeg) ? startGrapheme : 0;
-        for (let g = graphemeStart; g < endGrapheme && g < graphemes.length; g++) {
+        const graphemeStart = i === startSeg ? startGrapheme : 0;
+        for (
+          let g = graphemeStart;
+          g < endGrapheme && g < graphemes.length;
+          g++
+        ) {
           partialText += graphemes[g];
           partialWidth += fitAdvances[g] ?? 0;
           boundaryOffsets.push(content.length + partialText.length);
@@ -881,7 +905,8 @@ export class Paragraph {
         content += partialText;
         totalWidth += partialWidth;
         if (i === startSeg) {
-          charStart = info.charStart + this.graphemeOffset(segText, startGrapheme);
+          charStart =
+            info.charStart + this.graphemeOffset(segText, startGrapheme);
         }
         charEnd = info.charStart + this.graphemeOffset(segText, endGrapheme);
         continue;
@@ -897,7 +922,11 @@ export class Paragraph {
         let runWidth = totalWidth - segWidth;
         for (let g = 0; g < graphemes.length; g++) {
           runWidth += fitAdvances[g] ?? 0;
-          boundaryOffsets.push(content.length - segText.length + this.graphemeEndOffset(graphemes, g));
+          boundaryOffsets.push(
+            content.length -
+              segText.length +
+              this.graphemeEndOffset(graphemes, g),
+          );
           prefixWidths.push(runWidth);
         }
       } else {
@@ -934,7 +963,9 @@ export class Paragraph {
     if (cached != null) return cached;
 
     if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
-      const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+      const segmenter = new Intl.Segmenter(undefined, {
+        granularity: "grapheme",
+      });
       cached = [];
       for (const gs of segmenter.segment(text)) {
         cached.push(gs.segment);
@@ -955,7 +986,10 @@ export class Paragraph {
     return offset;
   }
 
-  private graphemeEndOffset(graphemes: string[], graphemeIndex: number): number {
+  private graphemeEndOffset(
+    graphemes: string[],
+    graphemeIndex: number,
+  ): number {
     let offset = 0;
     for (let i = 0; i <= graphemeIndex && i < graphemes.length; i++) {
       offset += graphemes[i]!.length;
@@ -999,7 +1033,9 @@ export class Paragraph {
       const spanStart = this.preparedTextLength;
 
       // Use pretext's analyzeText + measureAnalysis pipeline
-      const measured = measureSpanText(sourceSpan.content, style.font);
+      const measured = measureSpanText(sourceSpan.content, style.font, {
+        whiteSpace: "pre-line",
+      });
       measuredSpans.push(measured);
 
       // Build segment info for SpanBox creation
@@ -1021,7 +1057,8 @@ export class Paragraph {
     }
 
     // Combine all measured spans into a single PreparedLineBreakData
-    const { prepared, segments, segmentStarts } = combineMeasuredSpans(measuredSpans);
+    const { prepared, segments, segmentStarts } =
+      combineMeasuredSpans(measuredSpans);
     this.preparedLineBreakData = prepared;
 
     // Compute intrinsic width (widest line at infinite width)

--- a/packages/core/src/type/_types/text-painter/layout.ts
+++ b/packages/core/src/type/_types/text-painter/layout.ts
@@ -50,7 +50,9 @@ let sharedGraphemeSegmenter: Intl.Segmenter | null = null;
 
 function getSharedGraphemeSegmenter(): Intl.Segmenter {
   if (sharedGraphemeSegmenter === null) {
-    sharedGraphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    sharedGraphemeSegmenter = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    });
   }
   return sharedGraphemeSegmenter;
 }
@@ -83,7 +85,11 @@ function buildBaseCjkUnits(
     unitIsSingleKinsokuEnd = false;
   }
 
-  function startUnit(grapheme: string, start: number, graphemeContainsCJK: boolean): void {
+  function startUnit(
+    grapheme: string,
+    start: number,
+    graphemeContainsCJK: boolean,
+  ): void {
     unitParts = [grapheme];
     unitStart = start;
     unitContainsCJK = graphemeContainsCJK;
@@ -96,7 +102,8 @@ function buildBaseCjkUnits(
     unitContainsCJK = unitContainsCJK || graphemeContainsCJK;
     const graphemeEndsWithClosingQuote = endsWithClosingQuote(grapheme);
     if (grapheme.length === 1 && leftStickyPunctuation.has(grapheme)) {
-      unitEndsWithClosingQuote = unitEndsWithClosingQuote || graphemeEndsWithClosingQuote;
+      unitEndsWithClosingQuote =
+        unitEndsWithClosingQuote || graphemeEndsWithClosingQuote;
     } else {
       unitEndsWithClosingQuote = graphemeEndsWithClosingQuote;
     }
@@ -148,7 +155,10 @@ function mergeKeepAllTextUnits(units: MeasuredTextUnit[]): MeasuredTextUnit[] {
 
   function flushCurrent(): void {
     merged.push({
-      text: currentTextParts.length === 1 ? currentTextParts[0]! : currentTextParts.join(""),
+      text:
+        currentTextParts.length === 1
+          ? currentTextParts[0]!
+          : currentTextParts.join(""),
       start: currentStart,
     });
   }
@@ -204,7 +214,12 @@ export function measureSpanText(
   options?: PrepareOptions,
 ): MeasuredSpanResult {
   const wordBreak = options?.wordBreak ?? "normal";
-  const analysis = analyzeText(text, getEngineProfile(), options?.whiteSpace, wordBreak);
+  const analysis = analyzeText(
+    text,
+    getEngineProfile(),
+    options?.whiteSpace,
+    wordBreak,
+  );
   return measureAnalysisWithFont(analysis, font, wordBreak);
 }
 
@@ -218,8 +233,16 @@ function measureAnalysisWithFont(
     font,
     textMayContainEmoji(analysis.normalized),
   );
-  const discretionaryHyphenWidth = getCorrectedSegmentWidth("-", getSegmentMetrics("-", cache), emojiCorrection);
-  const spaceWidth = getCorrectedSegmentWidth(" ", getSegmentMetrics(" ", cache), emojiCorrection);
+  const discretionaryHyphenWidth = getCorrectedSegmentWidth(
+    "-",
+    getSegmentMetrics("-", cache),
+    emojiCorrection,
+  );
+  const spaceWidth = getCorrectedSegmentWidth(
+    " ",
+    getSegmentMetrics(" ", cache),
+    emojiCorrection,
+  );
   const tabStopAdvance = spaceWidth * 8;
 
   if (analysis.len === 0) {
@@ -246,7 +269,9 @@ function measureAnalysisWithFont(
   const breakableFitAdvances: (number[] | null)[] = [];
   const segments: string[] = [];
   const segmentStarts: number[] = [];
-  const preparedStartByAnalysisIndex = Array.from<number>({ length: analysis.len });
+  const preparedStartByAnalysisIndex = Array.from<number>({
+    length: analysis.len,
+  });
 
   function pushMeasuredSegment(
     text: string,
@@ -279,13 +304,13 @@ function measureAnalysisWithFont(
     const textMetrics = getSegmentMetrics(text, cache);
     const width = getCorrectedSegmentWidth(text, textMetrics, emojiCorrection);
     const lineEndFitAdvance =
-      kind === "space" || kind === "preserved-space" || kind === "zero-width-break"
+      kind === "space" ||
+      kind === "preserved-space" ||
+      kind === "zero-width-break"
         ? 0
         : width;
     const lineEndPaintAdvance =
-      kind === "space" || kind === "zero-width-break"
-        ? 0
-        : width;
+      kind === "space" || kind === "zero-width-break" ? 0 : width;
 
     if (allowOverflowBreaks && wordLike && text.length > 1) {
       let fitMode: BreakableFitMode = "sum-graphemes";
@@ -358,9 +383,8 @@ function measureAnalysisWithFont(
 
     if (segKind === "text" && segMetrics.containsCJK) {
       const baseUnits = buildBaseCjkUnits(segText, engineProfile);
-      const measuredUnits = wordBreak === "keep-all"
-        ? mergeKeepAllTextUnits(baseUnits)
-        : baseUnits;
+      const measuredUnits =
+        wordBreak === "keep-all" ? mergeKeepAllTextUnits(baseUnits) : baseUnits;
 
       for (let i = 0; i < measuredUnits.length; i++) {
         const unit = measuredUnits[i]!;
@@ -378,7 +402,11 @@ function measureAnalysisWithFont(
     pushMeasuredTextSegment(segText, segKind, segStart, segWordLike, true);
   }
 
-  const chunks = mapAnalysisChunksToPreparedChunks(analysis.chunks, preparedStartByAnalysisIndex, widths.length);
+  const chunks = mapAnalysisChunksToPreparedChunks(
+    analysis.chunks,
+    preparedStartByAnalysisIndex,
+    widths.length,
+  );
 
   return {
     widths,
@@ -425,14 +453,44 @@ function mapAnalysisChunksToPreparedChunks(
   return preparedChunks;
 }
 
+function compilePreparedChunksFromKinds(
+  kinds: SegmentBreakKind[],
+): PreparedLineChunk[] {
+  if (kinds.length === 0) {
+    return [];
+  }
+
+  const preparedChunks: PreparedLineChunk[] = [];
+  let startSegmentIndex = 0;
+
+  for (let i = 0; i < kinds.length; i++) {
+    if (kinds[i] !== "hard-break") continue;
+
+    preparedChunks.push({
+      startSegmentIndex,
+      endSegmentIndex: i,
+      consumedEndSegmentIndex: i + 1,
+    });
+    startSegmentIndex = i + 1;
+  }
+
+  if (startSegmentIndex < kinds.length) {
+    preparedChunks.push({
+      startSegmentIndex,
+      endSegmentIndex: kinds.length,
+      consumedEndSegmentIndex: kinds.length,
+    });
+  }
+
+  return preparedChunks;
+}
+
 /**
  * Combine multiple MeasuredSpanResults (one per source span) into a single
  * PreparedLineBreakData for the line walker. Also returns per-segment metadata
  * for creating SpanBoxes after layout.
  */
-export function combineMeasuredSpans(
-  spans: MeasuredSpanResult[],
-): {
+export function combineMeasuredSpans(spans: MeasuredSpanResult[]): {
   prepared: PreparedLineBreakData;
   segments: string[];
   segmentStarts: number[];
@@ -485,11 +543,8 @@ export function combineMeasuredSpans(
   let simpleLineWalkFastPath = true;
   let discretionaryHyphenWidth = 0;
   let tabStopAdvance = 0;
-  const allChunks: PreparedLineChunk[] = [];
 
   for (const span of spans) {
-    const offset = widths.length;
-
     widths.push(...span.widths);
     lineEndFitAdvances.push(...span.lineEndFitAdvances);
     lineEndPaintAdvances.push(...span.lineEndPaintAdvances);
@@ -509,28 +564,13 @@ export function combineMeasuredSpans(
     if (tabStopAdvance === 0 && span.tabStopAdvance > 0) {
       tabStopAdvance = span.tabStopAdvance;
     }
-
-    // Offset chunk indices
-    for (const chunk of span.chunks) {
-      allChunks.push({
-        startSegmentIndex: chunk.startSegmentIndex + offset,
-        endSegmentIndex: chunk.endSegmentIndex + offset,
-        consumedEndSegmentIndex: chunk.consumedEndSegmentIndex + offset,
-      });
-    }
   }
 
-  // When combining multiple spans that each have no hard breaks (<=1 chunk),
-  // the combined result might still be simple if no individual span broke it
+  const allChunks = compilePreparedChunksFromKinds(kinds);
+
+  // Span boundaries should stay inline; only actual hard breaks split chunks.
   if (allChunks.length > 1) {
     simpleLineWalkFastPath = false;
-  } else if (allChunks.length === 0 && widths.length > 0) {
-    // No chunks from any span — treat as single chunk spanning everything
-    allChunks.push({
-      startSegmentIndex: 0,
-      endSegmentIndex: widths.length,
-      consumedEndSegmentIndex: widths.length,
-    });
   }
 
   return {

--- a/packages/core/src/type/_types/text-span.ts
+++ b/packages/core/src/type/_types/text-span.ts
@@ -35,7 +35,11 @@ class TextSpan extends InlineSpan {
   }
 
   protected override computeToPlainText(): string {
-    return this.text || "";
+    let plainText = this.text ?? "";
+    this.children.forEach(child => {
+      plainText += child.toPlainText();
+    });
+    return plainText;
   }
 
   build(


### PR DESCRIPTION
## Summary
- preserve `\n` as a default hard line break in RichText/Text layout to match Flutter behavior
- keep nested TextSpan children inline by deriving prepared chunks from actual hard-break segments instead of span boundaries
- make `TextSpan.toPlainText()` include child text and rename the RichText story label to `With Children`

## Verification
- `pnpm --filter flitter-core build`
- `pnpm --filter flitter-storybook build`
- internal bundled check: `analyzeText("Hello\nLine Changed!!", ..., "pre-line")` now emits a `hard-break`, and `combineMeasuredSpans()` keeps adjacent styled spans in a single chunk without forced line splits