### PR TITLE
Implement canvas repaint boundaries for partial repaint

### DIFF
--- a/packages/core/src/component/RepaintBoundary.ts
+++ b/packages/core/src/component/RepaintBoundary.ts
@@ -1,0 +1,4 @@
+import { classToFunction } from "../utils";
+import _RepaintBoundary from "./base/BaseRepaintBoundary";
+
+export default classToFunction(_RepaintBoundary);

--- a/packages/core/src/component/base/BaseClipPath.ts
+++ b/packages/core/src/component/base/BaseClipPath.ts
@@ -1,5 +1,5 @@
 import SingleChildRenderObject from "../../renderobject/SingleChildRenderObject";
-import type { Offset, Size } from "../../type";
+import { Offset, type Size } from "../../type";
 import type { Path } from "../../type/_types/_path";
 import {
   SvgPainter,

--- a/packages/core/src/component/base/BaseRepaintBoundary.ts
+++ b/packages/core/src/component/base/BaseRepaintBoundary.ts
@@ -1,0 +1,32 @@
+import { CanvasPainter } from "../../framework";
+import SingleChildRenderObject from "../../renderobject/SingleChildRenderObject";
+import SingleChildRenderObjectWidget from "../../widget/SingleChildRenderObjectWidget";
+import type Widget from "../../widget/Widget";
+
+class BaseRepaintBoundary extends SingleChildRenderObjectWidget {
+  constructor({ child, key }: { child?: Widget; key?: any } = {}) {
+    super({ child, key });
+  }
+
+  override createRenderObject(): SingleChildRenderObject {
+    return new RenderRepaintBoundary();
+  }
+}
+
+class RenderRepaintBoundary extends SingleChildRenderObject {
+  constructor() {
+    super({ isPainter: false });
+  }
+
+  protected override createCanvasPainter(): CanvasPainter {
+    return new RepaintBoundaryCanvasPainter(this);
+  }
+}
+
+class RepaintBoundaryCanvasPainter extends CanvasPainter {
+  override get isRepaintBoundary() {
+    return true;
+  }
+}
+
+export default BaseRepaintBoundary;

--- a/packages/core/src/component/index.ts
+++ b/packages/core/src/component/index.ts
@@ -55,6 +55,7 @@ import Painter from "./base/BaseCustomPaint";
 import TextField from "./TextField";
 import Image from "./Image";
 import LayoutBuilder from "./LayoutBuilder";
+import RepaintBoundary from "./RepaintBoundary";
 
 export {
   Painter,
@@ -112,4 +113,5 @@ export {
   TextField,
   Image,
   LayoutBuilder,
+  RepaintBoundary,
 };

--- a/packages/core/src/framework/renderer/canvas/canvas-painter.ts
+++ b/packages/core/src/framework/renderer/canvas/canvas-painter.ts
@@ -1,5 +1,4 @@
-import { Rect, type Offset } from "../../../type";
-import { NotImplementedError } from "../../../exception";
+import { Offset, Rect } from "../../../type";
 import { Painter } from "../renderer";
 import type { CanvasRenderPipeline } from "./canvas-renderer";
 import type { CanvasPaintingContext } from "./canvas-painting-context";
@@ -14,9 +13,9 @@ export class CanvasPainter extends Painter {
     return false;
   }
 
-
   paint(context: CanvasPaintingContext, offset: Offset) {
     this.needsPaint = false;
+    this.renderObject.needsCompositedLayerUpdate = false;
     this.performPaint(context, offset);
   }
 
@@ -32,19 +31,31 @@ export class CanvasPainter extends Painter {
 
   get paintBounds(): Rect {
     return Rect.fromLTWH({
-      left: this.offset.x,
-      top: this.offset.y,
+      left: 0,
+      top: 0,
       width: this.size.width,
       height: this.size.height,
     });
   }
 
-  #layer!: ContainerLayer;
+  #layer: ContainerLayer | null = null;
   get layer() {
     return this.#layer;
   }
-  set layer(layer: ContainerLayer) {
+  set layer(layer: ContainerLayer | null) {
     this.#layer = layer;
+  }
+
+  get compositedOffset(): Offset {
+    let offset = this.offset;
+    let node = this.renderObject.parent;
+
+    while (node != null && node.canvasPainter.layer == null) {
+      offset = node.offset.plus(offset);
+      node = node.parent;
+    }
+
+    return offset;
   }
 
   updateCompositedLayer(oldLayer: ContainerLayer | null) {
@@ -52,10 +63,30 @@ export class CanvasPainter extends Painter {
       this.isRepaintBoundary,
       "updateCompositedLayer must be called on a repaint boundary",
     );
-    return oldLayer ?? new OffsetLayer();
+    const layer = oldLayer ?? new OffsetLayer(Offset.Constants.zero);
+    if (layer instanceof OffsetLayer) {
+      layer.offset = this.compositedOffset;
+    }
+    return layer;
   }
 
   skippedPaintingOnLayer() {
-    throw new NotImplementedError("skippedPaintingOnLayer on CanvasPainter");
+    const layer = this.layer;
+    if (layer == null || layer.attached) return;
+
+    let node = this.renderObject.parent;
+    while (node != null) {
+      if (node.canvasPainter.isRepaintBoundary) {
+        const ancestorLayer = node.canvasPainter.layer;
+        if (ancestorLayer == null) {
+          break;
+        }
+        if (ancestorLayer.attached) {
+          break;
+        }
+        node.needsPaint = true;
+      }
+      node = node.parent;
+    }
   }
 }

--- a/packages/core/src/framework/renderer/canvas/canvas-painting-context.ts
+++ b/packages/core/src/framework/renderer/canvas/canvas-painting-context.ts
@@ -3,19 +3,28 @@ import type { RenderObject } from "../../../renderobject";
 import { Offset, type Rect } from "../../../type";
 import {
   type ContainerLayer,
+  OffsetLayer,
   PictureLayer,
   PictureRecorder,
   type Layer,
 } from "./layer";
-import { NotImplementedError } from "../../../exception";
 
 type AncestorNode = { node: RenderObject; offset: Offset };
 
 type CollectedPainter = {
+  kind: "painter";
   renderObject: RenderObject;
   offset: Offset;
   ancestors: AncestorNode[];
 };
+
+type CollectedBoundary = {
+  kind: "boundary";
+  renderObject: RenderObject;
+  offset: Offset;
+};
+
+type CollectedPaintItem = CollectedPainter | CollectedBoundary;
 
 type CanvasProxy = CanvasRenderingContext2D & {
   __enterSuppress: () => void;
@@ -44,7 +53,7 @@ function createCanvasProxy(ctx: CanvasRenderingContext2D): CanvasProxy {
   let suppressing = false;
 
   const proxy = new Proxy(ctx, {
-    get(target, prop, receiver) {
+    get(target, prop) {
       if (prop === "__enterSuppress")
         return () => {
           suppressing = true;
@@ -69,14 +78,13 @@ function createCanvasProxy(ctx: CanvasRenderingContext2D): CanvasProxy {
             suppressDepth--;
           };
         }
-        // Suppress pixel-drawing operations during ancestor replay
         if (DRAWING_OPS.has(prop)) {
           return NOOP;
         }
       }
 
-      const val = Reflect.get(target, prop, target);
-      return typeof val === "function" ? val.bind(target) : val;
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
     },
     set(target, prop, value) {
       return Reflect.set(target, prop, value);
@@ -89,11 +97,15 @@ function createCanvasProxy(ctx: CanvasRenderingContext2D): CanvasProxy {
 export class CanvasPaintingContext {
   #estimateBound: Rect;
   #containerLayer: ContainerLayer;
+
   constructor(containerLayer: ContainerLayer, estimateBound: Rect) {
     this.#containerLayer = containerLayer;
     this.#estimateBound = estimateBound;
   }
-  #currentLayer!: PictureLayer | null;
+
+  #currentLayer: PictureLayer | null = null;
+  #recorder: PictureRecorder | null = null;
+  #ctx: CanvasProxy | null = null;
 
   /**
    * When true, paintChild becomes a no-op. Used during z-ordered
@@ -108,6 +120,7 @@ export class CanvasPaintingContext {
       node.canvasPainter.isRepaintBoundary,
       "isRepaintBoundary must be true on repaintCompositedChild",
     );
+
     let childLayer = node.canvasPainter.layer;
     if (childLayer == null) {
       childLayer = node.canvasPainter.updateCompositedLayer(null);
@@ -122,71 +135,86 @@ export class CanvasPaintingContext {
       updatedChildLayer.removeAllChildren();
     }
 
+    node.needsCompositedLayerUpdate = false;
+
     const childContext = new CanvasPaintingContext(
       childLayer,
       node.canvasPainter.paintBounds,
     );
 
-    // Phase 1: Collect all painter render objects with ancestor node chains
-    const painters: CollectedPainter[] = [];
-    CanvasPaintingContext.#collectPainters(
+    const items: CollectedPaintItem[] = [];
+    CanvasPaintingContext.#collectPaintItems(
       node,
       Offset.Constants.zero,
       [],
-      painters,
+      items,
+      true,
     );
 
-    // Phase 2: Sort by z-order (calculated by ZOrderCalculatorVisitor)
-    painters.sort((a, b) => a.renderObject.zOrder - b.renderObject.zOrder);
+    items.sort((a, b) => {
+      const aOrder =
+        a.kind === "boundary"
+          ? a.renderObject.minDescendantZOrder
+          : a.renderObject.zOrder;
+      const bOrder =
+        b.kind === "boundary"
+          ? b.renderObject.minDescendantZOrder
+          : b.renderObject.zOrder;
+      return aOrder - bOrder;
+    });
 
-    // Phase 3: Paint each painter in z-order with ancestor ctx state replayed
     const proxyCanvas = childContext.canvas as unknown as CanvasProxy;
     childContext.#skipChildPainting = true;
-    for (const { renderObject, offset, ancestors } of painters) {
+    for (const item of items) {
+      if (item.kind === "boundary") {
+        childContext.compositeChild(item.renderObject, item.offset);
+        continue;
+      }
+
+      const { renderObject, offset, ancestors } = item;
       proxyCanvas.__raw.save();
-      // Replay ancestors with suppressed save/restore
-      for (const { node: ancestorNode, offset: ancOffset } of ancestors) {
+      for (const { node: ancestorNode, offset: ancestorOffset } of ancestors) {
         proxyCanvas.__enterSuppress();
-        ancestorNode.canvasPainter.paint(childContext, ancOffset);
+        ancestorNode.canvasPainter.paint(childContext, ancestorOffset);
         proxyCanvas.__exitSuppress();
       }
-      // Paint the actual painter
       renderObject.canvasPainter.paint(childContext, offset);
       proxyCanvas.__raw.restore();
     }
     childContext.#skipChildPainting = false;
 
-    childContext.stopRecording();
+    childContext.stopRecordingIfNeeded();
   }
 
-  /**
-   * Walk the render object tree and collect all painter render objects
-   * with their accumulated offsets and ancestor node chains.
-   */
-  static #collectPainters(
+  static #collectPaintItems(
     node: RenderObject,
     offset: Offset,
     ancestorChain: AncestorNode[],
-    result: CollectedPainter[],
+    result: CollectedPaintItem[],
+    isRoot = false,
   ) {
+    if (!isRoot && node.canvasPainter.isRepaintBoundary) {
+      result.push({
+        kind: "boundary",
+        renderObject: node,
+        offset,
+      });
+      return;
+    }
+
     if (node.isPainter) {
       result.push({
+        kind: "painter",
         renderObject: node,
         offset,
         ancestors: [...ancestorChain],
       });
     }
 
-    // All nodes go into the ancestor chain. During ancestor replay,
-    // the proxy suppresses pixel-drawing operations (fillRect, fill,
-    // stroke, etc.) so only canvas state changes (transforms, clips,
-    // opacity) persist. This means any node type — whether it draws
-    // pixels (Container) or only modifies state (Transform, ClipPath)
-    // — can safely be replayed as an ancestor.
     const childAncestorChain = [...ancestorChain, { node, offset }];
 
     node.visitChildren(child => {
-      CanvasPaintingContext.#collectPainters(
+      CanvasPaintingContext.#collectPaintItems(
         child,
         offset.plus(child.offset),
         childAncestorChain,
@@ -195,12 +223,21 @@ export class CanvasPaintingContext {
     });
   }
 
-  static updateLayerProperties(_: RenderObject): void {
-    throw new NotImplementedError("updateLayerProperties is not implemented");
+  static updateLayerProperties(node: RenderObject): void {
+    assert(
+      node.canvasPainter.layer != null,
+      "layer must exist on updateLayerProperties",
+    );
+
+    const layer = node.canvasPainter.layer!;
+    const updatedLayer = node.canvasPainter.updateCompositedLayer(layer);
+    assert(
+      layer === updatedLayer,
+      "updateCompositedLayer must return the same layer",
+    );
+    node.needsCompositedLayerUpdate = false;
   }
 
-  #recorder!: PictureRecorder;
-  #ctx!: CanvasProxy | null;
   get canvas(): CanvasRenderingContext2D {
     if (this.#ctx == null) {
       this.#startRecording();
@@ -212,34 +249,61 @@ export class CanvasPaintingContext {
     this.#currentLayer = new PictureLayer(this.#estimateBound);
     this.#recorder = new PictureRecorder(this.#estimateBound);
     this.#ctx = createCanvasProxy(this.#recorder.createCanvasContext());
-    this.#containerLayer.append(this.#currentLayer!);
+    this.#appendLayer(this.#currentLayer);
   }
 
-  stopRecording() {
-    this.#currentLayer!.picture = this.#recorder.endRecording();
-    this.#recorder = null as unknown as PictureRecorder;
+  stopRecordingIfNeeded() {
+    if (this.#currentLayer == null || this.#recorder == null) return;
+    this.#currentLayer.picture = this.#recorder.endRecording();
+    this.#recorder = null;
     this.#ctx = null;
     this.#currentLayer = null;
   }
 
   addLayer(layer: Layer) {
-    this.stopRecording();
+    this.stopRecordingIfNeeded();
     this.#appendLayer(layer);
   }
 
   #appendLayer(layer: Layer) {
+    layer.remove();
     this.#containerLayer.append(layer);
   }
 
-  /**
-   * Paint a child RenderObject.
-   *
-   * When #skipChildPainting is true (during z-ordered paint phase),
-   * this is a no-op because each painter is invoked individually
-   * in z-order from repaintCompositedChild.
-   */
   paintChild(child: RenderObject, offset: Offset) {
     if (this.#skipChildPainting) return;
+
+    if (child.canvasPainter.isRepaintBoundary) {
+      this.compositeChild(child, offset);
+      return;
+    }
+
     child.canvasPainter.paint(this, offset);
+  }
+
+  compositeChild(child: RenderObject, offset: Offset) {
+    this.stopRecordingIfNeeded();
+    this.#compositeChild(child, offset);
+  }
+
+  #compositeChild(child: RenderObject, offset: Offset) {
+    assert(
+      child.canvasPainter.isRepaintBoundary,
+      "isRepaintBoundary must be true on compositeChild",
+    );
+
+    if (child.needsPaint || child.canvasPainter.layer == null) {
+      CanvasPaintingContext.repaintCompositedChild(child);
+    } else if (child.needsCompositedLayerUpdate) {
+      CanvasPaintingContext.updateLayerProperties(child);
+    }
+
+    const childLayer = child.canvasPainter.layer;
+    assert(
+      childLayer instanceof OffsetLayer,
+      "repaint boundary layer must be an OffsetLayer",
+    );
+    childLayer.offset = offset;
+    this.#appendLayer(childLayer);
   }
 }

--- a/packages/core/src/framework/renderer/canvas/canvas-renderer.ts
+++ b/packages/core/src/framework/renderer/canvas/canvas-renderer.ts
@@ -2,7 +2,6 @@ import type { RenderObject } from "../../../renderobject/RenderObject";
 import { RenderPipeline } from "../renderer";
 import { Constraints } from "../../../type";
 import { CanvasPaintingContext } from "./canvas-painting-context";
-import { assert } from "../../../utils";
 import { SceneBuilder } from "./layer";
 
 export class CanvasRenderPipeline extends RenderPipeline {
@@ -36,11 +35,11 @@ export class CanvasRenderPipeline extends RenderPipeline {
     dirties
       .sort((a, b) => b.depth - a.depth)
       .forEach(node => {
+        if (!node.needsPaint && !node.needsCompositedLayerUpdate) {
+          return;
+        }
+
         if (node.canvasPainter.layer?.attached) {
-          assert(
-            node.canvasPainter.isRepaintBoundary,
-            "isRepaintBoundary must be true on flushPaint",
-          );
           if (node.needsPaint) {
             CanvasPaintingContext.repaintCompositedChild(node);
           } else {
@@ -65,17 +64,39 @@ export class CanvasRenderPipeline extends RenderPipeline {
       if (!parent.needsPaint) {
         parent.needsPaint = true;
         this.needsPaintRenderObjects.push(parent);
+        this.requestVisualUpdate();
       }
     }
+  }
+
+  override markNeedsCompositedLayerUpdate(renderObject: RenderObject): void {
+    if (renderObject.needsPaint || renderObject.needsCompositedLayerUpdate) {
+      return;
+    }
+
+    renderObject.needsCompositedLayerUpdate = true;
+
+    if (renderObject.canvasPainter.layer != null) {
+      this.needsPaintRenderObjects.push(renderObject);
+      this.requestVisualUpdate();
+      return;
+    }
+
+    this.markNeedsPaint(renderObject);
   }
 
   override markNeedsPaintTransformUpdate(renderObject: RenderObject): void {
     renderObject.needsPaintTransformUpdate = true;
     this.needsPaintTransformUpdateRenderObjects.push(renderObject);
-    this.markNeedsPaint(renderObject);
+    this.requestVisualUpdate();
   }
 
   override didChangePaintTransform(renderObjet: RenderObject): void {
+    if (renderObjet.canvasPainter.layer != null) {
+      renderObjet.markNeedsCompositedLayerUpdate();
+      return;
+    }
+
     renderObjet.markNeedsPaint();
   }
 
@@ -84,7 +105,7 @@ export class CanvasRenderPipeline extends RenderPipeline {
     const ctx = this.#prepareCanvas(
       this.renderContext.view as HTMLCanvasElement,
     );
-    this.renderView.canvasPainter.layer.buildScene(builder);
+    this.renderView.canvasPainter.layer?.buildScene(builder);
     builder.render(ctx);
   }
 

--- a/packages/core/src/framework/renderer/canvas/layer.ts
+++ b/packages/core/src/framework/renderer/canvas/layer.ts
@@ -1,6 +1,8 @@
 import type { Offset, Matrix4, Rect } from "../../../type";
+import type { Path } from "../../../type/_types/_path";
 import type { CanvasRenderPipeline } from "./canvas-renderer";
 export abstract class Layer {
+  parent: ContainerLayer | null = null;
   attached: boolean = false;
   owner!: CanvasRenderPipeline;
 
@@ -8,6 +10,15 @@ export abstract class Layer {
     this.attached = true;
     this.owner = owner;
   }
+
+  detach() {
+    this.attached = false;
+  }
+
+  remove() {
+    this.parent?.removeChild(this);
+  }
+
   abstract addToScene(builder: SceneBuilder): void;
 }
 
@@ -29,6 +40,21 @@ export class PictureLayer extends Layer {
 
 export class ContainerLayer extends Layer {
   children: Layer[] = [];
+
+  override attach(owner: CanvasRenderPipeline) {
+    super.attach(owner);
+    this.visitChildren(child => {
+      child.attach(owner);
+    });
+  }
+
+  override detach() {
+    this.visitChildren(child => {
+      child.detach();
+    });
+    super.detach();
+  }
+
   override addToScene(builder: SceneBuilder) {
     this.visitChildren(layer => {
       layer.addToScene(builder);
@@ -41,6 +67,10 @@ export class ContainerLayer extends Layer {
     }
   }
   removeAllChildren() {
+    this.children.forEach(child => {
+      child.parent = null;
+      child.detach();
+    });
     this.children = [];
   }
 
@@ -49,39 +79,244 @@ export class ContainerLayer extends Layer {
   }
 
   append(child: Layer) {
+    child.remove();
     this.children.push(child);
-    child.attach(this.owner);
+    child.parent = this;
+    if (this.attached) {
+      child.attach(this.owner);
+    }
+  }
+
+  removeChild(child: Layer) {
+    const index = this.children.indexOf(child);
+    if (index === -1) return;
+    this.children.splice(index, 1);
+    child.parent = null;
+    child.detach();
   }
 }
 
 export class OffsetLayer extends ContainerLayer {
-  offset!: Offset;
+  offset: Offset;
+
+  constructor(offset: Offset) {
+    super();
+    this.offset = offset;
+  }
+
+  override addToScene(builder: SceneBuilder) {
+    builder.pushOffset(this.offset);
+    super.addToScene(builder);
+    builder.pop();
+  }
 }
 export class TransformLayer extends OffsetLayer {
-  transform!: Matrix4;
+  transform: Matrix4;
+
+  constructor({
+    offset,
+    transform,
+  }: {
+    offset: Offset;
+    transform: Matrix4;
+  }) {
+    super(offset);
+    this.transform = transform;
+  }
+
+  override addToScene(builder: SceneBuilder) {
+    builder.pushTransform(this.transform, this.offset);
+    this.visitChildren(layer => {
+      layer.addToScene(builder);
+    });
+    builder.pop();
+  }
+}
+
+export class OpacityLayer extends OffsetLayer {
+  opacity: number;
+
+  constructor({
+    offset,
+    opacity,
+  }: {
+    offset: Offset;
+    opacity: number;
+  }) {
+    super(offset);
+    this.opacity = opacity;
+  }
+
+  override addToScene(builder: SceneBuilder) {
+    builder.pushOpacity(this.opacity, this.offset);
+    this.visitChildren(layer => {
+      layer.addToScene(builder);
+    });
+    builder.pop();
+  }
+}
+
+export class ClipPathLayer extends OffsetLayer {
+  clipPath: Path;
+
+  constructor({
+    offset,
+    clipPath,
+  }: {
+    offset: Offset;
+    clipPath: Path;
+  }) {
+    super(offset);
+    this.clipPath = clipPath;
+  }
+
+  override addToScene(builder: SceneBuilder) {
+    builder.pushClipPath(this.clipPath, this.offset);
+    this.visitChildren(layer => {
+      layer.addToScene(builder);
+    });
+    builder.pop();
+  }
+}
+
+export class ClipRectLayer extends OffsetLayer {
+  clipRect: Rect;
+
+  constructor({
+    offset,
+    clipRect,
+  }: {
+    offset: Offset;
+    clipRect: Rect;
+  }) {
+    super(offset);
+    this.clipRect = clipRect;
+  }
+
+  override addToScene(builder: SceneBuilder) {
+    builder.pushClipRect(this.clipRect, this.offset);
+    this.visitChildren(layer => {
+      layer.addToScene(builder);
+    });
+    builder.pop();
+  }
 }
 
 export class SceneBuilder {
-  #pictures: { x: number; y: number; picture: Picture }[] = [];
+  #commands: (
+    | { type: "save" }
+    | { type: "restore" }
+    | { type: "translate"; offset: Offset }
+    | { type: "transform"; offset: Offset; transform: Matrix4 }
+    | { type: "opacity"; opacity: number; offset: Offset }
+    | { type: "clipPath"; clipPath: Path; offset: Offset }
+    | { type: "clipRect"; clipRect: Rect; offset: Offset }
+    | { type: "picture"; x: number; y: number; picture: Picture }
+  )[] = [];
 
   render(ctx: CanvasRenderingContext2D) {
-    /**
-     * Vertical layering not yet considered.
-     * Addition required!
-     */
-    for (const { x, y, picture } of this.#pictures) {
-      ctx.drawImage(
-        picture.toImage(),
-        x,
-        y,
-        picture.size.width,
-        picture.size.height,
-      );
+    for (const command of this.#commands) {
+      switch (command.type) {
+        case "save":
+          ctx.save();
+          break;
+        case "restore":
+          ctx.restore();
+          break;
+        case "translate":
+          ctx.translate(command.offset.x, command.offset.y);
+          break;
+        case "transform": {
+          ctx.translate(command.offset.x, command.offset.y);
+          const arr = command.transform._m4storage;
+          ctx.transform(arr[0], arr[1], arr[4], arr[5], arr[12], arr[13]);
+          break;
+        }
+        case "opacity":
+          ctx.translate(command.offset.x, command.offset.y);
+          ctx.globalAlpha *= command.opacity;
+          break;
+        case "clipPath":
+          ctx.translate(command.offset.x, command.offset.y);
+          ctx.clip(command.clipPath.toCanvasPath());
+          break;
+        case "clipRect":
+          ctx.translate(command.offset.x, command.offset.y);
+          ctx.beginPath();
+          ctx.rect(
+            command.clipRect.left,
+            command.clipRect.top,
+            command.clipRect.width,
+            command.clipRect.height,
+          );
+          ctx.clip();
+          break;
+        case "picture":
+          ctx.drawImage(
+            command.picture.toImage(),
+            command.x,
+            command.y,
+            command.picture.size.width,
+            command.picture.size.height,
+          );
+          break;
+      }
     }
   }
 
   addPicture(props: { x: number; y: number; picture: Picture }) {
-    this.#pictures.push(props);
+    this.#commands.push({
+      type: "picture",
+      ...props,
+    });
+  }
+
+  pushOffset(offset: Offset) {
+    this.#commands.push({ type: "save" });
+    this.#commands.push({
+      type: "translate",
+      offset,
+    });
+  }
+
+  pushTransform(transform: Matrix4, offset: Offset) {
+    this.#commands.push({ type: "save" });
+    this.#commands.push({
+      type: "transform",
+      offset,
+      transform,
+    });
+  }
+
+  pushOpacity(opacity: number, offset: Offset) {
+    this.#commands.push({ type: "save" });
+    this.#commands.push({
+      type: "opacity",
+      opacity,
+      offset,
+    });
+  }
+
+  pushClipPath(clipPath: Path, offset: Offset) {
+    this.#commands.push({ type: "save" });
+    this.#commands.push({
+      type: "clipPath",
+      clipPath,
+      offset,
+    });
+  }
+
+  pushClipRect(clipRect: Rect, offset: Offset) {
+    this.#commands.push({ type: "save" });
+    this.#commands.push({
+      type: "clipRect",
+      clipRect,
+      offset,
+    });
+  }
+
+  pop() {
+    this.#commands.push({ type: "restore" });
   }
 }
 

--- a/packages/core/src/framework/renderer/renderer.ts
+++ b/packages/core/src/framework/renderer/renderer.ts
@@ -188,6 +188,7 @@ export abstract class RenderPipeline {
   }
   abstract disposeRenderObject(renderObject: RenderObject): void;
   abstract markNeedsPaint(renderObject: RenderObject): void;
+  abstract markNeedsCompositedLayerUpdate(renderObject: RenderObject): void;
   abstract markNeedsPaintTransformUpdate(renderObject: RenderObject): void;
   abstract didChangePaintTransform(renderObject: RenderObject): void;
 }

--- a/packages/core/src/framework/renderer/svg/svg-renderer.ts
+++ b/packages/core/src/framework/renderer/svg/svg-renderer.ts
@@ -78,10 +78,14 @@ export class SvgRenderPipeline extends RenderPipeline {
     this.requestVisualUpdate();
   }
 
+  override markNeedsCompositedLayerUpdate(renderObject: RenderObject): void {
+    this.markNeedsPaint(renderObject);
+  }
+
   override markNeedsPaintTransformUpdate(renderObject: RenderObject): void {
     renderObject.needsPaintTransformUpdate = true;
     this.needsPaintTransformUpdateRenderObjects.push(renderObject);
-    this.markNeedsPaint(renderObject);
+    this.requestVisualUpdate();
   }
 
   override didChangePaintTransform(renderObject: RenderObject): void {

--- a/packages/core/src/renderobject/RenderObject.ts
+++ b/packages/core/src/renderobject/RenderObject.ts
@@ -17,6 +17,7 @@ export class RenderObject {
   paintTransform: Matrix4 = Matrix4.Constants.identity;
   parent?: RenderObject;
   needsPaint = true;
+  needsCompositedLayerUpdate = false;
   needsLayout = true;
   needsPaintTransformUpdate = true;
   depth = 0;
@@ -188,6 +189,10 @@ export class RenderObject {
 
   markNeedsPaint() {
     this.renderOwner.markNeedsPaint(this);
+  }
+
+  markNeedsCompositedLayerUpdate() {
+    this.renderOwner.markNeedsCompositedLayerUpdate(this);
   }
 
   localToGlobal(additionalOffset: Offset = Offset.Constants.zero) {


### PR DESCRIPTION
## Summary
- add a `RepaintBoundary` component for canvas retained rendering
- implement retained layer bookkeeping for canvas repaint boundaries, including detached-layer handling and layer property updates
- upgrade the canvas scene/layer pipeline to support multi-layer composition without changing existing transform/clip paint semantics

## Validation
- `pnpm run chromatic`
  - Build 138 passed with 1 visual change remaining
  - https://www.chromatic.com/build?appId=65f00810b3cff25c69b9afd3&number=138
- `pnpm run perf:trace -- --note "Issue #123 repaint boundary compositing"`
  - runApp: 25.7178ms
  - mount: 10.3057ms
  - draw: 15.0677ms
  - layout: 8.9249ms
  - paint: 2.5511ms

Closes #123